### PR TITLE
fix(vendors): stabilize query key to prevent infinite loading

### DIFF
--- a/src/hooks/useVendors.ts
+++ b/src/hooks/useVendors.ts
@@ -24,7 +24,15 @@ export const useVendors = (
   } = { page: 1, limit: 20 }
 ) => {
   return useQuery({
-    queryKey: ['vendors', 'list', params],
+    queryKey: [
+      'vendors',
+      'list',
+      params.page,
+      params.limit,
+      params.status ?? '',
+      params.search ?? '',
+      params.tags ? [...params.tags].sort().join(',') : '',
+    ],
     queryFn: () => vendorsService.getVendors(params),
     ...queryOptions.dynamic,
   });


### PR DESCRIPTION
## Summary
- stabilize React Query key for vendor list to avoid endless refetching

## Testing
- `pnpm lint`
- `pnpm exec eslint src/pages/VendorsPage.jsx`
- `pnpm run test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68987d43edcc832dadf990bc96439aed