### PR TITLE
feat: add vendor creation modal

### DIFF
--- a/src/services/vendors.ts
+++ b/src/services/vendors.ts
@@ -116,7 +116,10 @@ export const createVendor = async (vendorData: {
   taxId: string;
   email?: string;
   phone?: string;
+  rating?: number;
   tags?: string[];
+  status?: 'active' | 'inactive';
+  blocked?: boolean;
   contacts?: Array<{
     name: string;
     email: string;
@@ -134,9 +137,9 @@ export const createVendor = async (vendorData: {
       tags: vendorData.tags || [],
       contacts: vendorData.contacts || [],
       categories: vendorData.categories || [],
-      rating: 0,
-      blocked: false,
-      status: 'active',
+      rating: vendorData.rating ?? 0,
+      blocked: vendorData.blocked ?? false,
+      status: vendorData.status || 'active',
       createdAt: new Date(),
       updatedAt: new Date()
     };


### PR DESCRIPTION
## Summary
- add modal to create vendors with full details
- allow saving rating, status and blocked fields to Firestore

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6898933206f8832db1d6f8c4a49f0fa6