### PR TITLE
feat: add user and role management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,15 +1,18 @@
 import { Link, useLocation } from 'react-router-dom';
 import { useUIStore } from '../stores/ui';
 import { cn } from '../lib/utils';
+import { useAuth } from '@/contexts/AuthContext';
 
 const navigation = [
-  { name: 'Solicitações', href: '/requests', icon: '📝' },
-  { name: 'Fornecedores', href: '/vendors', icon: '🏢' },
+  { name: 'Solicitações', href: '/requests', icon: '📝', page: 'requests' },
+  { name: 'Fornecedores', href: '/vendors', icon: '🏢', page: 'vendors' },
+  { name: 'Usuários', href: '/users', icon: '👥', page: 'users' },
 ];
 
 export const Sidebar = () => {
   const location = useLocation();
   const { sidebarOpen, sidebarCollapsed } = useUIStore();
+  const { hasPageAccess } = useAuth();
 
   if (!sidebarOpen) return null;
 
@@ -35,7 +38,7 @@ export const Sidebar = () => {
 
         {/* Navegação */}
         <nav className="flex-1 px-2 py-4 space-y-1">
-          {navigation.map((item) => {
+          {navigation.filter((item) => hasPageAccess(item.page)).map((item) => {
             const isActive = location.pathname === item.href;
             return (
               <Link

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useState } from 'react';
 
 const AuthContext = createContext({});
 
@@ -25,8 +25,36 @@ export const AuthProvider = ({ children }) => {
     updatedAt: new Date(),
   };
 
+  const [users, setUsers] = useState([
+    { id: '1', name: 'Administrador', email: 'admin@empresa.com', role: 'admin' },
+    { id: '2', name: 'Financeiro', email: 'finance@empresa.com', role: 'finance' },
+    { id: '3', name: 'Usuário Padrão', email: 'user@empresa.com', role: 'user' },
+  ]);
+
+  const addUser = (user) => {
+    setUsers((prev) => [...prev, { id: String(Date.now()), ...user }]);
+  };
+
+  const [permissions, setPermissions] = useState({
+    requests: ['admin', 'finance', 'user'],
+    vendors: ['admin', 'finance'],
+    users: ['admin'],
+  });
+
+  const updatePermissions = (page, roles) => {
+    setPermissions((prev) => ({ ...prev, [page]: roles }));
+  };
+
+  const hasPageAccess = (page) =>
+    permissions[page]?.includes(mockUser.role) || mockUser.role === 'admin';
+
   const authValue = {
     user: mockUser,
+    users,
+    addUser,
+    permissions,
+    updatePermissions,
+    hasPageAccess,
     isAuthenticated: true,
     isLoading: false,
     login: () => {},

--- a/src/pages/UsersPage.jsx
+++ b/src/pages/UsersPage.jsx
@@ -1,0 +1,147 @@
+import React, { useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+
+export const UsersPage = () => {
+  const { users, addUser, permissions, updatePermissions } = useAuth();
+  const [form, setForm] = useState({ name: '', email: '', role: 'user' });
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!form.name || !form.email) return;
+    addUser(form);
+    setForm({ name: '', email: '', role: 'user' });
+  };
+
+  const roles = ['admin', 'finance', 'user'];
+  const pages = Object.keys(permissions);
+  const pageLabels = { requests: 'Solicitações', vendors: 'Fornecedores', users: 'Usuários' };
+
+  const handlePermissionToggle = (page, role) => {
+    const roleList = permissions[page] || [];
+    const updated = roleList.includes(role)
+      ? roleList.filter((r) => r !== role)
+      : [...roleList, role];
+    updatePermissions(page, updated);
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold tracking-tight">Usuários &amp; Roles</h1>
+
+      <section className="bg-white p-6 rounded-lg border">
+        <h2 className="text-xl font-semibold mb-4">Cadastrar Novo Usuário</h2>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Nome</label>
+            <input
+              name="name"
+              value={form.name}
+              onChange={handleChange}
+              className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">E-mail</label>
+            <input
+              name="email"
+              type="email"
+              value={form.email}
+              onChange={handleChange}
+              className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Role</label>
+            <select
+              name="role"
+              value={form.role}
+              onChange={handleChange}
+              className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            >
+              {roles.map((r) => (
+                <option key={r} value={r}>
+                  {r}
+                </option>
+              ))}
+            </select>
+          </div>
+          <button
+            type="submit"
+            className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+          >
+            Adicionar Usuário
+          </button>
+        </form>
+      </section>
+
+      <section className="bg-white p-6 rounded-lg border">
+        <h2 className="text-xl font-semibold mb-4">Usuários Cadastrados</h2>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead>
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">E-mail</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Role</th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {users.map((u) => (
+                <tr key={u.id}>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{u.name}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{u.email}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{u.role}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="bg-white p-6 rounded-lg border">
+        <h2 className="text-xl font-semibold mb-4">Permissões por Página</h2>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead>
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Página</th>
+                {roles.map((role) => (
+                  <th
+                    key={role}
+                    className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+                  >
+                    {role}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {pages.map((page) => (
+                <tr key={page}>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {pageLabels[page] || page}
+                  </td>
+                  {roles.map((role) => (
+                    <td key={role} className="px-6 py-4 text-center">
+                      <input
+                        type="checkbox"
+                        checked={permissions[page]?.includes(role)}
+                        onChange={() => handlePermissionToggle(page, role)}
+                      />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -2,14 +2,27 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 import { Layout } from '../components/Layout';
 import { RequestsPage } from '../pages/RequestsPage';
 import { VendorsPage } from '../pages/VendorsPage';
+import { UsersPage } from '../pages/UsersPage';
+import { useAuth } from '../contexts/AuthContext';
 
 export const AppRoutes = () => {
+  const { hasPageAccess } = useAuth();
   return (
     <Routes>
       <Route path="/" element={<Layout />}>
         <Route index element={<Navigate to="requests" replace />} />
-        <Route path="requests" element={<RequestsPage />} />
-        <Route path="vendors" element={<VendorsPage />} />
+        <Route
+          path="requests"
+          element={hasPageAccess('requests') ? <RequestsPage /> : <Navigate to="/" replace />}
+        />
+        <Route
+          path="vendors"
+          element={hasPageAccess('vendors') ? <VendorsPage /> : <Navigate to="/" replace />}
+        />
+        <Route
+          path="users"
+          element={hasPageAccess('users') ? <UsersPage /> : <Navigate to="/" replace />}
+        />
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>


### PR DESCRIPTION
## Summary
- add context state for users and page permissions
- add users & roles page with registration and permission matrix
- restrict routes and sidebar items based on role access

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6898963f4c90832d9ff2ce657874b4d5