### PR TITLE
Add requests page to sidebar

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,10 +1,11 @@
 import { Link, useLocation } from 'react-router-dom';
 import { useUIStore } from '../stores/ui';
 import { cn } from '../lib/utils';
+import { ROUTES } from '../constants';
 
 const navigation = [
-  { name: 'Solicitações', href: '/requests', icon: '📝' },
-  { name: 'Fornecedores', href: '/vendors', icon: '🏢' },
+  { name: 'Solicitações', href: ROUTES.REQUESTS, icon: '📝' },
+  { name: 'Fornecedores', href: ROUTES.VENDORS, icon: '🏢' },
 ];
 
 export const Sidebar = () => {


### PR DESCRIPTION
## Summary
- add requests route to sidebar navigation using centralized routes

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_689897825be8832db8034dc2c4ad1b29