### PR TITLE
Fix cost centers sidebar navigation route

### DIFF
--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -26,8 +26,16 @@ export const AppRoutes = () => {
           element={
             hasPageAccess('cost-centers') ? <CostCentersPage /> : <Navigate to="/" replace />
           }
+        />
+        <Route
           path="vendor-approvals"
-          element={hasPageAccess('vendorApprovals') ? <VendorApprovalsPage /> : <Navigate to="/" replace />}
+          element={
+            hasPageAccess('vendorApprovals') ? (
+              <VendorApprovalsPage />
+            ) : (
+              <Navigate to="/" replace />
+            )
+          }
         />
         <Route
           path="users"


### PR DESCRIPTION
## Summary
- correct cost centers route in app router so sidebar link works

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6898a00d3124832dacfb614e4f8e13e0