### PR TITLE
feat: vendor approval history and dossier

### DIFF
--- a/src/pages/VendorApprovalsPage.jsx
+++ b/src/pages/VendorApprovalsPage.jsx
@@ -1,10 +1,35 @@
-import React from 'react';
-import { useVendors, useApproveVendor, useRejectVendor, useRequestMoreInfoVendor } from '@/hooks/useVendors';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  useVendors,
+  useApproveVendor,
+  useRejectVendor,
+  useRequestMoreInfoVendor,
+} from '@/hooks/useVendors';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
-import { formatCNPJ } from '@/utils';
+import { formatCNPJ, formatDate } from '@/utils';
 
 export const VendorApprovalsPage = () => {
-  const { data: vendorsData, isLoading, isError } = useVendors({ status: 'pending', page: 1, limit: 50 });
+  const { data: vendorsData, isLoading, isError } = useVendors({
+    status: 'pending',
+    page: 1,
+    limit: 50,
+  });
+  const [search, setSearch] = useState('');
+  const [sortBy, setSortBy] = useState('updatedAt');
+  const [sortOrder, setSortOrder] = useState('desc');
+  const navigate = useNavigate();
+
+  const {
+    data: historyData,
+    isLoading: historyLoading,
+    isError: historyError,
+  } = useVendors({
+    page: 1,
+    limit: 100,
+    sortBy,
+    sortOrder,
+  });
   const approveVendor = useApproveVendor();
   const rejectVendor = useRejectVendor();
   const requestInfoVendor = useRequestMoreInfoVendor();
@@ -30,6 +55,25 @@ export const VendorApprovalsPage = () => {
   };
 
   const vendors = vendorsData?.data ?? [];
+  const historyVendors = (historyData?.data ?? []).filter(
+    (v) => v.status !== 'pending'
+  );
+  const filteredHistory = historyVendors.filter((v) => {
+    const q = search.toLowerCase();
+    return (
+      v.name.toLowerCase().includes(q) ||
+      (v.taxId && v.taxId.includes(search))
+    );
+  });
+
+  const toggleSort = (column) => {
+    if (sortBy === column) {
+      setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortBy(column);
+      setSortOrder('asc');
+    }
+  };
 
   return (
     <div className="space-y-6">
@@ -86,6 +130,78 @@ export const VendorApprovalsPage = () => {
                       >
                         Mais Info
                       </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <h2 className="text-2xl font-bold tracking-tight">Histórico de Aprovações</h2>
+      <div className="bg-white rounded-lg border overflow-hidden">
+        <div className="p-4">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Filtrar fornecedores..."
+            className="w-full px-3 py-2 border rounded-md"
+          />
+        </div>
+        {historyLoading ? (
+          <div className="flex justify-center py-12">
+            <LoadingSpinner size="lg" />
+          </div>
+        ) : historyError ? (
+          <div className="text-center py-12 text-red-500">
+            Erro ao carregar histórico
+          </div>
+        ) : filteredHistory.length === 0 ? (
+          <div className="text-center py-12">
+            <p className="text-gray-500">Nenhum histórico encontrado</p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th
+                    onClick={() => toggleSort('name')}
+                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer"
+                  >
+                    Fornecedor
+                  </th>
+                  <th
+                    onClick={() => toggleSort('status')}
+                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer"
+                  >
+                    Status
+                  </th>
+                  <th
+                    onClick={() => toggleSort('updatedAt')}
+                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer"
+                  >
+                    Atualizado
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {filteredHistory.map((vendor) => (
+                  <tr
+                    key={vendor.id}
+                    className="hover:bg-gray-50 cursor-pointer"
+                    onClick={() => navigate(`/vendors/${vendor.id}`)}
+                  >
+                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                      {vendor.name}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {vendor.status}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {formatDate(vendor.updatedAt)}
                     </td>
                   </tr>
                 ))}

--- a/src/pages/VendorDossierPage.jsx
+++ b/src/pages/VendorDossierPage.jsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { useVendor } from '@/hooks/useVendors';
+import { useRequests } from '@/hooks/useRequests';
+import { useEntityTimeline } from '@/hooks/useAudit';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import { formatCNPJ, formatCurrency, formatDate } from '@/utils';
+
+export const VendorDossierPage = () => {
+  const { id } = useParams();
+  const { data: vendor, isLoading, isError } = useVendor(id || '');
+  const { data: requestsData, isLoading: requestsLoading } = useRequests({
+    page: 1,
+    limit: 20,
+    vendorId: id,
+  });
+  const { data: timelineData, isLoading: timelineLoading } = useEntityTimeline(
+    'vendor',
+    id || '',
+    20
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-12">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
+  }
+
+  if (isError || !vendor) {
+    return <div className="text-center py-12">Fornecedor não encontrado</div>;
+  }
+
+  const requests = requestsData?.data ?? [];
+  const timeline = timelineData ?? [];
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold tracking-tight">Dossiê do Fornecedor</h1>
+
+      <div className="bg-white p-6 rounded-lg border space-y-2">
+        <div><span className="font-semibold">Nome: </span>{vendor.name}</div>
+        <div><span className="font-semibold">CNPJ: </span>{formatCNPJ(vendor.taxId)}</div>
+        <div><span className="font-semibold">Status: </span>{vendor.status}</div>
+        {vendor.email && (
+          <div><span className="font-semibold">Email: </span>{vendor.email}</div>
+        )}
+        {vendor.phone && (
+          <div><span className="font-semibold">Telefone: </span>{vendor.phone}</div>
+        )}
+      </div>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-4">Histórico de Despesas</h2>
+        <div className="bg-white rounded-lg border overflow-hidden">
+          {requestsLoading ? (
+            <div className="flex justify-center py-6">
+              <LoadingSpinner size="lg" />
+            </div>
+          ) : requests.length === 0 ? (
+            <div className="text-center py-6">Nenhuma despesa encontrada</div>
+          ) : (
+            <table className="w-full">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Número</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Valor</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {requests.map((req) => (
+                  <tr key={req.id} className="hover:bg-gray-50">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {req.requestNumber || req.id}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {formatCurrency(req.amount)}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {req.status}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-4">Histórico de Aprovações</h2>
+        <div className="bg-white rounded-lg border overflow-hidden">
+          {timelineLoading ? (
+            <div className="flex justify-center py-6">
+              <LoadingSpinner size="lg" />
+            </div>
+          ) : timeline.length === 0 ? (
+            <div className="text-center py-6">Nenhum registro encontrado</div>
+          ) : (
+            <table className="w-full">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Ação</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Data</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {timeline.map((log) => (
+                  <tr key={log.id} className="hover:bg-gray-50">
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {log.action}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {formatDate(log.timestamp)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default VendorDossierPage;

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -3,6 +3,7 @@ import { Layout } from '../components/Layout';
 import { RequestsPage } from '../pages/RequestsPage';
 import { VendorsPage } from '../pages/VendorsPage';
 import { VendorApprovalsPage } from '../pages/VendorApprovalsPage';
+import { VendorDossierPage } from '../pages/VendorDossierPage';
 import { UsersPage } from '../pages/UsersPage';
 import { CostCentersPage } from '../pages/CostCentersPage';
 import { useAuth } from '../contexts/AuthContext';
@@ -20,6 +21,10 @@ export const AppRoutes = () => {
         <Route
           path="vendors"
           element={hasPageAccess('vendors') ? <VendorsPage /> : <Navigate to="/" replace />}
+        />
+        <Route
+          path="vendors/:id"
+          element={hasPageAccess('vendors') ? <VendorDossierPage /> : <Navigate to="/" replace />}
         />
         <Route
           path="cost-centers"


### PR DESCRIPTION
## Summary
- add sortable and filterable vendor approval history with dossier link
- create vendor dossier page with general info, expenses and approvals
- wire vendor dossier route into application

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6898a1c74294832d95ace550cf6ec5aa