### PR TITLE
fix: fetch active vendors and cost centers

### DIFF
--- a/src/services/costCenters.ts
+++ b/src/services/costCenters.ts
@@ -283,19 +283,22 @@ export const checkCodeExists = async (code: string, excludeId?: string): Promise
 // Obter centros de custo ativos
 export const getActiveCostCenters = async (): Promise<CostCenter[]> => {
   try {
+    // Buscar centros de custo ativos no Firestore. A ordenação é realizada
+    // em memória para evitar necessidade de índices compostos.
     const q = query(
       collection(db, COLLECTION_NAME),
-      where('status', '==', 'active'),
-      orderBy('name')
+      where('status', '==', 'active')
     );
 
     const snapshot = await getDocs(q);
-    return snapshot.docs.map(doc => ({
-      id: doc.id,
-      ...doc.data(),
-      createdAt: doc.data().createdAt?.toDate() || new Date(),
-      updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-    })) as CostCenter[];
+    return snapshot.docs
+      .map(doc => ({
+        id: doc.id,
+        ...doc.data(),
+        createdAt: doc.data().createdAt?.toDate() || new Date(),
+        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name)) as CostCenter[];
   } catch (error) {
     console.error('Erro ao buscar centros de custo ativos:', error);
     throw error;


### PR DESCRIPTION
## Summary
- ensure active vendors are fetched from Firestore without relying on missing `blocked` field and sort client-side
- query active cost centers from Firestore and sort in memory to avoid index requirements

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6898a4f71660832d92e622e583b4e4c4