### PR TITLE
fix: fetch active vendors and cost centers

### DIFF
--- a/src/hooks/useCostCenters.ts
+++ b/src/hooks/useCostCenters.ts
@@ -55,7 +55,9 @@ export const useActiveCostCenters = () => {
   return useQuery<CostCenter[]>({
     queryKey: ['cost-centers', 'active'],
     queryFn: costCentersService.getActiveCostCenters,
-    initialData: [],
+    // Não passamos `initialData` para que o React Query efetue a
+    // solicitação ao Firebase em vez de considerar os dados já
+    // preenchidos com um array vazio.
     ...queryOptions.static,
   });
 };

--- a/src/hooks/useVendors.ts
+++ b/src/hooks/useVendors.ts
@@ -53,7 +53,9 @@ export const useActiveVendors = () => {
   return useQuery<Vendor[]>({
     queryKey: ['vendors', 'active'],
     queryFn: vendorsService.getActiveVendors,
-    initialData: [],
+    // Não fornecemos `initialData` para garantir que o React Query
+    // realize a busca no Firebase em vez de considerar a query já
+    // resolvida com um array vazio.
     ...queryOptions.static,
   });
 };

--- a/src/services/costCenters.ts
+++ b/src/services/costCenters.ts
@@ -283,19 +283,22 @@ export const checkCodeExists = async (code: string, excludeId?: string): Promise
 // Obter centros de custo ativos
 export const getActiveCostCenters = async (): Promise<CostCenter[]> => {
   try {
+    // Buscar centros de custo ativos no Firestore. A ordenação é realizada
+    // em memória para evitar necessidade de índices compostos.
     const q = query(
       collection(db, COLLECTION_NAME),
-      where('status', '==', 'active'),
-      orderBy('name')
+      where('status', '==', 'active')
     );
 
     const snapshot = await getDocs(q);
-    return snapshot.docs.map(doc => ({
-      id: doc.id,
-      ...doc.data(),
-      createdAt: doc.data().createdAt?.toDate() || new Date(),
-      updatedAt: doc.data().updatedAt?.toDate() || new Date(),
-    })) as CostCenter[];
+    return snapshot.docs
+      .map(doc => ({
+        id: doc.id,
+        ...doc.data(),
+        createdAt: doc.data().createdAt?.toDate() || new Date(),
+        updatedAt: doc.data().updatedAt?.toDate() || new Date(),
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name)) as CostCenter[];
   } catch (error) {
     console.error('Erro ao buscar centros de custo ativos:', error);
     throw error;


### PR DESCRIPTION
## Summary
- ensure active vendors are fetched from Firestore without relying on missing `blocked` field and sort client-side
- query active cost centers from Firestore and sort in memory to avoid index requirements
- remove default empty results so hooks actually fetch active vendors and cost centers

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6898a4f71660832d92e622e583b4e4c4