### PR TITLE
Track expense status changes and history view

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -17,12 +17,10 @@ export const ROLES = {
 
 // Status das solicitações
 export const REQUEST_STATUS = {
-  DRAFT: 'draft',
-  SUBMITTED: 'submitted',
-  IN_APPROVAL: 'in_approval',
-  APPROVED: 'approved',
+  PENDING_APPROVAL: 'pending_approval',
+  PENDING_PAYMENT: 'pending_payment',
   REJECTED: 'rejected',
-  SCHEDULED: 'scheduled',
+  CANCELLED: 'cancelled',
   PAID: 'paid'
 } as const;
 
@@ -58,13 +56,11 @@ export const ROLE_LABELS = {
 } as const;
 
 export const STATUS_LABELS = {
-  [REQUEST_STATUS.DRAFT]: 'Rascunho',
-  [REQUEST_STATUS.SUBMITTED]: 'Submetida',
-  [REQUEST_STATUS.IN_APPROVAL]: 'Em Aprovação',
-  [REQUEST_STATUS.APPROVED]: 'Aprovada',
+  [REQUEST_STATUS.PENDING_APPROVAL]: 'Ag. aprovação',
+  [REQUEST_STATUS.PENDING_PAYMENT]: 'Ag. pagamento',
   [REQUEST_STATUS.REJECTED]: 'Rejeitada',
-  [REQUEST_STATUS.SCHEDULED]: 'Agendada',
-  [REQUEST_STATUS.PAID]: 'Paga'
+  [REQUEST_STATUS.CANCELLED]: 'Cancelada',
+  [REQUEST_STATUS.PAID]: 'Pagamento realizado'
 } as const;
 
 export const STEP_STATUS_LABELS = {
@@ -87,13 +83,11 @@ export const DOCUMENT_TYPE_LABELS = {
 
 // Cores para status
 export const STATUS_COLORS = {
-  [REQUEST_STATUS.DRAFT]: 'gray',
-  [REQUEST_STATUS.SUBMITTED]: 'blue',
-  [REQUEST_STATUS.IN_APPROVAL]: 'yellow',
-  [REQUEST_STATUS.APPROVED]: 'green',
+  [REQUEST_STATUS.PENDING_APPROVAL]: 'yellow',
+  [REQUEST_STATUS.PENDING_PAYMENT]: 'blue',
   [REQUEST_STATUS.REJECTED]: 'red',
-  [REQUEST_STATUS.SCHEDULED]: 'purple',
-  [REQUEST_STATUS.PAID]: 'emerald'
+  [REQUEST_STATUS.CANCELLED]: 'gray',
+  [REQUEST_STATUS.PAID]: 'green'
 } as const;
 
 export const STEP_STATUS_COLORS = {

--- a/src/hooks/useRequests.ts
+++ b/src/hooks/useRequests.ts
@@ -153,8 +153,9 @@ export const useSubmitRequest = () => {
   const { success, error } = useNotifications();
 
   return useMutation({
-    mutationFn: requestsService.submitRequest,
-    onSuccess: (_, id) => {
+    mutationFn: ({ id, userId, userName }: { id: string; userId: string; userName: string }) =>
+      requestsService.submitRequest(id, userId, userName),
+    onSuccess: (_, { id }) => {
       // Invalidar queries relacionadas
       queryClient.invalidateQueries({ queryKey: queryKeys.requests });
       queryClient.invalidateQueries({ queryKey: queryKeys.request(id) });
@@ -273,8 +274,8 @@ export const useCancelRequest = () => {
   const { success, error } = useNotifications();
 
   return useMutation({
-    mutationFn: ({ id, reason }: { id: string; reason: string }) =>
-      requestsService.cancelRequest(id, reason),
+    mutationFn: ({ id, reason, userId, userName }: { id: string; reason: string; userId: string; userName: string }) =>
+      requestsService.cancelRequest(id, reason, userId, userName),
     onSuccess: (_, { id }) => {
       // Invalidar queries relacionadas
       queryClient.invalidateQueries({ queryKey: queryKeys.requests });

--- a/src/pages/RequestDetailsPage.jsx
+++ b/src/pages/RequestDetailsPage.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useRequest } from '@/hooks/useRequests';
+
+const statusLabels = {
+  pending_approval: 'Ag. aprovação',
+  pending_payment: 'Ag. pagamento',
+  rejected: 'Rejeitado',
+  cancelled: 'Cancelado',
+  paid: 'Pagamento realizado',
+};
+
+const formatDateTime = (date) =>
+  new Intl.DateTimeFormat('pt-BR', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(new Date(date));
+
+export const RequestDetailsPage = () => {
+  const { id } = useParams();
+  const { data: request, isLoading } = useRequest(id);
+
+  if (isLoading) return <div>Carregando...</div>;
+  if (!request) return <div>Solicitação não encontrada</div>;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Solicitação {request.requestNumber}</h1>
+        <Link to="/requests" className="text-blue-600 hover:underline text-sm">
+          Voltar
+        </Link>
+      </div>
+      <div>
+        <p className="mb-4"><strong>Status atual:</strong> {statusLabels[request.status] || request.status}</p>
+        <h2 className="text-xl font-semibold mb-2">Histórico de Status</h2>
+        <ul className="space-y-2">
+          {request.statusHistory?.map((entry, idx) => (
+            <li key={idx} className="border rounded p-2">
+              <div className="text-sm font-medium">{statusLabels[entry.status] || entry.status}</div>
+              <div className="text-xs text-gray-500">
+                {entry.changedByName} - {formatDateTime(entry.timestamp)}
+              </div>
+              {entry.reason && (
+                <div className="text-xs text-gray-600 mt-1">Motivo: {entry.reason}</div>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default RequestDetailsPage;

--- a/src/pages/RequestsPage.jsx
+++ b/src/pages/RequestsPage.jsx
@@ -50,20 +50,22 @@ export const RequestsPage = () => {
 
   const getStatusColor = (status) => {
     const colors = {
-      pending: 'bg-yellow-100 text-yellow-800',
-      approved: 'bg-green-100 text-green-800',
+      pending_approval: 'bg-yellow-100 text-yellow-800',
+      pending_payment: 'bg-purple-100 text-purple-800',
       rejected: 'bg-red-100 text-red-800',
-      paid: 'bg-blue-100 text-blue-800',
+      cancelled: 'bg-gray-200 text-gray-800',
+      paid: 'bg-green-100 text-green-800',
     };
     return colors[status] || 'bg-gray-100 text-gray-800';
   };
 
   const getStatusLabel = (status) => {
     const labels = {
-      pending: 'Pendente',
-      approved: 'Aprovado',
+      pending_approval: 'Ag. aprovação',
+      pending_payment: 'Ag. pagamento',
       rejected: 'Rejeitado',
-      paid: 'Pago',
+      cancelled: 'Cancelado',
+      paid: 'Pagamento realizado',
     };
     return labels[status] || status;
   };
@@ -127,8 +129,8 @@ export const RequestsPage = () => {
               <Clock className="w-6 h-6 text-yellow-600" />
             </div>
             <div className="ml-4">
-              <p className="text-sm font-medium text-gray-600">Pendentes</p>
-              <p className="text-2xl font-bold">{stats?.byStatus?.pending ?? 0}</p>
+              <p className="text-sm font-medium text-gray-600">Ag. aprovação</p>
+              <p className="text-2xl font-bold">{stats?.byStatus?.pending_approval ?? 0}</p>
             </div>
           </div>
         </div>
@@ -139,8 +141,8 @@ export const RequestsPage = () => {
               <CheckCircle className="w-6 h-6 text-green-600" />
             </div>
             <div className="ml-4">
-              <p className="text-sm font-medium text-gray-600">Aprovadas</p>
-              <p className="text-2xl font-bold">{stats?.byStatus?.approved ?? 0}</p>
+              <p className="text-sm font-medium text-gray-600">Ag. pagamento</p>
+              <p className="text-2xl font-bold">{stats?.byStatus?.pending_payment ?? 0}</p>
             </div>
           </div>
         </div>
@@ -181,10 +183,11 @@ export const RequestsPage = () => {
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             >
               <option value="">Todos os status</option>
-              <option value="pending">Pendente</option>
-              <option value="approved">Aprovado</option>
+              <option value="pending_approval">Ag. aprovação</option>
+              <option value="pending_payment">Ag. pagamento</option>
               <option value="rejected">Rejeitado</option>
-              <option value="paid">Pago</option>
+              <option value="cancelled">Cancelado</option>
+              <option value="paid">Pagamento realizado</option>
             </select>
           </div>
 
@@ -316,7 +319,7 @@ export const RequestsPage = () => {
                           >
                             <Eye className="w-4 h-4" />
                           </button>
-                          {request.status === 'pending' && (
+                          {request.status === 'pending_approval' && (
                             <>
                               <button
                                 onClick={() => alert('Aprovar solicitação (Demo)')}

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,6 +1,7 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { Layout } from '../components/Layout';
 import { RequestsPage } from '../pages/RequestsPage';
+import { RequestDetailsPage } from '../pages/RequestDetailsPage';
 import { VendorsPage } from '../pages/VendorsPage';
 import { VendorApprovalsPage } from '../pages/VendorApprovalsPage';
 import { VendorDossierPage } from '../pages/VendorDossierPage';
@@ -17,6 +18,10 @@ export const AppRoutes = () => {
         <Route
           path="requests"
           element={hasPageAccess('requests') ? <RequestsPage /> : <Navigate to="/" replace />}
+        />
+        <Route
+          path="requests/:id"
+          element={hasPageAccess('requests') ? <RequestDetailsPage /> : <Navigate to="/" replace />}
         />
         <Route
           path="vendors"

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -133,9 +133,9 @@ export const getDashboardKPIs = async (
     // Calcular KPIs financeiros
     const totalRequests = requests.length;
     const totalAmount = requests.reduce((sum, r) => sum + r.amount, 0);
-    const approvedRequests = requests.filter(r => ['approved', 'paid'].includes(r.status));
-    const pendingRequests = requests.filter(r => ['submitted', 'in_approval'].includes(r.status));
-    const rejectedRequests = requests.filter(r => r.status === 'rejected');
+    const approvedRequests = requests.filter(r => ['pending_payment', 'paid'].includes(r.status));
+    const pendingRequests = requests.filter(r => r.status === 'pending_approval');
+    const rejectedRequests = requests.filter(r => ['rejected', 'cancelled'].includes(r.status));
     const paidRequests = requests.filter(r => r.status === 'paid');
     
     const approvedAmount = approvedRequests.reduce((sum, r) => sum + r.amount, 0);
@@ -259,21 +259,19 @@ export const getRequestsByStatus = async (
     }, {} as Record<string, number>);
     
     const statusLabels = {
-      draft: 'Rascunho',
-      submitted: 'Enviado',
-      in_approval: 'Em Aprovação',
-      approved: 'Aprovado',
+      pending_approval: 'Ag. aprovação',
+      pending_payment: 'Ag. pagamento',
       rejected: 'Rejeitado',
-      paid: 'Pago',
+      cancelled: 'Cancelado',
+      paid: 'Pagamento realizado',
     };
-    
+
     const statusColors = {
-      draft: '#94a3b8',
-      submitted: '#3b82f6',
-      in_approval: '#f59e0b',
-      approved: '#10b981',
+      pending_approval: '#f59e0b',
+      pending_payment: '#3b82f6',
       rejected: '#ef4444',
-      paid: '#8b5cf6',
+      cancelled: '#6b7280',
+      paid: '#10b981',
     };
     
     return Object.entries(statusCounts).map(([status, count]) => ({
@@ -351,11 +349,11 @@ export const getTimeSeriesData = async (
       acc[periodKey].requests += 1;
       acc[periodKey].amount += request.amount;
       
-      if (['approved', 'paid'].includes(request.status)) {
+      if (['pending_payment', 'paid'].includes(request.status)) {
         acc[periodKey].approved += 1;
-      } else if (request.status === 'rejected') {
+      } else if (['rejected', 'cancelled'].includes(request.status)) {
         acc[periodKey].rejected += 1;
-      } else if (['submitted', 'in_approval'].includes(request.status)) {
+      } else if (request.status === 'pending_approval') {
         acc[periodKey].pending += 1;
       }
       

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,14 +2,20 @@
 
 export type Role = 'admin' | 'finance' | 'approver' | 'requester' | 'viewer';
 
-export type RequestStatus = 
-  | 'draft' 
-  | 'submitted' 
-  | 'in_approval' 
-  | 'approved' 
-  | 'rejected' 
-  | 'scheduled' 
+export type RequestStatus =
+  | 'pending_approval'
+  | 'pending_payment'
+  | 'rejected'
+  | 'cancelled'
   | 'paid';
+
+export interface StatusHistoryEntry {
+  status: RequestStatus;
+  changedBy: string;
+  changedByName: string;
+  timestamp: Date;
+  reason?: string;
+}
 
 export type StepStatus = 'pending' | 'approved' | 'rejected';
 
@@ -102,6 +108,7 @@ export interface PaymentRequest {
   // Workflow
   status: RequestStatus;
   steps: ApprovalStep[];
+  statusHistory: StatusHistoryEntry[];
   
   // Metadados
   createdBy: string;

--- a/src/utils/seedData.js
+++ b/src/utils/seedData.js
@@ -681,7 +681,7 @@ export const seedBudgets = [
 
 // Função para gerar solicitações de demonstração
 export const generateSeedRequests = () => {
-  const statuses = ['draft', 'pending', 'approved', 'paid', 'rejected', 'cancelled'];
+  const statuses = ['pending_approval', 'pending_payment', 'paid', 'rejected', 'cancelled'];
   const priorities = ['low', 'medium', 'high', 'urgent'];
   const paymentMethods = ['transfer', 'check', 'cash', 'card'];
   
@@ -715,7 +715,7 @@ export const generateSeedRequests = () => {
       dueDate: status !== 'draft' ? randomDate(new Date(), new Date(2024, 11, 31)) : null,
       notes: `Observações da solicitação ${i}`,
       attachments: [],
-      approvals: status === 'approved' || status === 'paid' ? [
+      approvals: status === 'pending_payment' || status === 'paid' ? [
         {
           level: 1,
           approverId: 'approver-001',


### PR DESCRIPTION
## Summary
- log all request status transitions with user and timestamp
- introduce pending approval/payment workflow and status labels
- add request details page to review status history

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898aa05ac24832dbce7946a3f195060