### PR TITLE
feat: add invoice info and attachments to request form

### DIFF
--- a/src/services/requests.ts
+++ b/src/services/requests.ts
@@ -188,6 +188,7 @@ export const getRequests = async (
 export const createRequest = async (requestData: {
   description: string;
   amount: number;
+  invoiceNumber?: string;
   vendorId: string;
   vendorName: string;
   costCenterId: string;
@@ -213,6 +214,7 @@ export const createRequest = async (requestData: {
       requestNumber,
       description: requestData.description,
       amount: requestData.amount,
+      invoiceNumber: requestData.invoiceNumber || null,
       vendorId: requestData.vendorId,
       vendorName: requestData.vendorName,
       costCenterId: requestData.costCenterId,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -97,6 +97,7 @@ export interface PaymentRequest {
   categoryId: string;
   vendorId: string;
   vendorName?: string;
+  invoiceNumber?: string;
   requestNumber?: string;
   dueDate: Date;
   costType?: CostType;
@@ -114,8 +115,9 @@ export interface PaymentRequest {
   createdBy: string;
   createdAt: Date;
   updatedAt: Date;
-  
+
   // Anexos e pagamento
+  attachments?: string[];
   attachmentsCount: number;
   hasInvoice: boolean;
   paymentDate?: Date;
@@ -205,6 +207,7 @@ export interface CreateRequestForm {
   categoryId: string;
   vendorId: string;
   vendorName?: string;
+  invoiceNumber?: string;
   costType?: CostType;
   invoiceDate?: string;
   competenceDate?: string;


### PR DESCRIPTION
## Summary
- add invoice number, gross amount, and file uploads for Boleto and NF in new request modal
- store invoice number and attachments when creating payment requests
- extend request types to include invoice metadata

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_689b0d9bb888832db0cfd27a6fda752e