### PR TITLE
feat: add reports page and navigation

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -11,6 +11,7 @@ const navigation = [
   { name: 'Aprovação Forn.', href: '/vendor-approvals', icon: '✅', page: 'vendorApprovals' },
   { name: 'Aprov. Financeira', href: '/financial-approvals', icon: '💸', page: 'financialApprovals' },
   { name: 'Pagamentos', href: '/payments', icon: '💳', page: 'payments' },
+  { name: 'Relatórios', href: '/reports', icon: '📊', page: 'reports' },
   { name: 'Usuários', href: '/users', icon: '👥', page: 'users' },
 ];
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -192,6 +192,7 @@ export const ROUTES = {
   BUDGETS: '/budgets',
   POLICIES: '/policies',
   DOCUMENTS: '/documents',
+  REPORTS: '/reports',
   ADMIN: '/admin',
   AUDIT: '/admin/audit',
   PROFILE: '/profile',

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -71,6 +71,7 @@ export const AuthProvider = ({ children }) => {
     'cost-centers': ['finance', 'cost_center_owner'],
     financialApprovals: ['finance'],
     payments: ['finance'],
+    reports: ['finance'],
   });
 
   const updatePermissions = (page, roles) => {

--- a/src/pages/ReportsPage.jsx
+++ b/src/pages/ReportsPage.jsx
@@ -1,0 +1,136 @@
+import React, { useState } from 'react';
+
+const availableColumns = [
+  { value: 'id', label: 'ID' },
+  { value: 'title', label: 'Título' },
+  { value: 'amount', label: 'Valor' },
+  { value: 'status', label: 'Status' },
+  { value: 'createdAt', label: 'Criado em' },
+];
+
+const availableMetrics = [
+  { value: 'count', label: 'Contagem' },
+  { value: 'sum', label: 'Soma' },
+  { value: 'average', label: 'Média' },
+];
+
+export const ReportsPage = () => {
+  const [showBuilder, setShowBuilder] = useState(false);
+  const [selectedColumns, setSelectedColumns] = useState([]);
+  const [filters, setFilters] = useState([{ column: '', value: '' }]);
+  const [metric, setMetric] = useState('count');
+
+  const toggleColumn = (col) => {
+    setSelectedColumns((prev) =>
+      prev.includes(col) ? prev.filter((c) => c !== col) : [...prev, col]
+    );
+  };
+
+  const handleFilterChange = (index, field, value) => {
+    setFilters((prev) =>
+      prev.map((f, i) => (i === index ? { ...f, [field]: value } : f))
+    );
+  };
+
+  const addFilterRow = () => {
+    setFilters((prev) => [...prev, { column: '', value: '' }]);
+  };
+
+  const handleGenerate = () => {
+    // Placeholder for generating report
+    // In a real app, this would fetch data based on selections
+    console.log({ selectedColumns, filters, metric });
+    alert('Relatório gerado (exemplo).');
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold tracking-tight">Relatórios</h1>
+
+      {!showBuilder && (
+        <button
+          onClick={() => setShowBuilder(true)}
+          className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+        >
+          Novo Relatório
+        </button>
+      )}
+
+      {showBuilder && (
+        <div className="space-y-6 bg-white p-6 rounded-lg border">
+          <div>
+            <h2 className="text-xl font-semibold mb-2">Colunas Disponíveis</h2>
+            <div className="space-y-2">
+              {availableColumns.map((col) => (
+                <label key={col.value} className="flex items-center space-x-2">
+                  <input
+                    type="checkbox"
+                    checked={selectedColumns.includes(col.value)}
+                    onChange={() => toggleColumn(col.value)}
+                  />
+                  <span>{col.label}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <h2 className="text-xl font-semibold mb-2">Métrica</h2>
+            <select
+              value={metric}
+              onChange={(e) => setMetric(e.target.value)}
+              className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            >
+              {availableMetrics.map((m) => (
+                <option key={m.value} value={m.value}>
+                  {m.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <h2 className="text-xl font-semibold mb-2">Filtros</h2>
+            {filters.map((filter, idx) => (
+              <div key={idx} className="flex space-x-2 mb-2">
+                <select
+                  value={filter.column}
+                  onChange={(e) => handleFilterChange(idx, 'column', e.target.value)}
+                  className="px-2 py-1 border border-gray-300 rounded-md"
+                >
+                  <option value="">Coluna</option>
+                  {availableColumns.map((col) => (
+                    <option key={col.value} value={col.value}>
+                      {col.label}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  value={filter.value}
+                  onChange={(e) => handleFilterChange(idx, 'value', e.target.value)}
+                  placeholder="Valor"
+                  className="flex-1 px-2 py-1 border border-gray-300 rounded-md"
+                />
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={addFilterRow}
+              className="text-sm text-blue-600 hover:underline"
+            >
+              Adicionar filtro
+            </button>
+          </div>
+
+          <button
+            onClick={handleGenerate}
+            className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700"
+          >
+            Gerar Relatório
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+

--- a/src/pages/UsersPage.jsx
+++ b/src/pages/UsersPage.jsx
@@ -30,6 +30,7 @@ export const UsersPage = () => {
     vendors: 'Fornecedores',
     users: 'Usuários',
     'cost-centers': 'Centros de Custo',
+    reports: 'Relatórios',
   };
 
   const handlePermissionToggle = (page, role) => {

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -9,6 +9,7 @@ import { UsersPage } from '../pages/UsersPage';
 import { CostCentersPage } from '../pages/CostCentersPage';
 import { FinancialApprovalsPage } from '../pages/FinancialApprovalsPage';
 import { PaymentManagementPage } from '../pages/PaymentManagementPage';
+import { ReportsPage } from '../pages/ReportsPage';
 import { useAuth } from '../contexts/AuthContext';
 
 export const AppRoutes = () => {
@@ -64,6 +65,16 @@ export const AppRoutes = () => {
           element={
             hasPageAccess('payments') ? (
               <PaymentManagementPage />
+            ) : (
+              <Navigate to="/" replace />
+            )
+          }
+        />
+        <Route
+          path="reports"
+          element={
+            hasPageAccess('reports') ? (
+              <ReportsPage />
             ) : (
               <Navigate to="/" replace />
             )


### PR DESCRIPTION
## Summary
- add custom reports page with column selection, filters, and metrics
- register reports route and permissions
- link reports page in sidebar navigation

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689b0e0b98b0832d83875558dfdad204