### PR TITLE
feat: add vendor details modal

### DIFF
--- a/src/components/VendorDetailsModal.jsx
+++ b/src/components/VendorDetailsModal.jsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from './ui/dialog';
+import { LoadingSpinner } from './ui/loading-spinner';
+import { useVendor } from '@/hooks/useVendors';
+import { useDocumentsByEntity } from '@/hooks/useDocuments';
+import { formatCNPJ } from '@/utils';
+
+export const VendorDetailsModal = ({
+  vendorId,
+  open,
+  onClose,
+  onApprove,
+  onReject,
+  onRequestInfo,
+  approveDisabled,
+  rejectDisabled,
+  requestInfoDisabled,
+}) => {
+  const { data: vendor, isLoading: vendorLoading } = useVendor(vendorId || '');
+  const { data: docsData, isLoading: docsLoading } = useDocumentsByEntity('vendor', vendorId || '');
+  const documents = docsData ?? [];
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+      <DialogContent className="sm:max-w-xl max-h-[90vh] overflow-y-auto">
+        {vendorLoading ? (
+          <div className="flex justify-center py-12">
+            <LoadingSpinner size="lg" />
+          </div>
+        ) : vendor ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>{vendor.name}</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-2 text-sm">
+              <div><span className="font-semibold">CNPJ: </span>{formatCNPJ(vendor.taxId)}</div>
+              {vendor.email && (
+                <div><span className="font-semibold">Email: </span>{vendor.email}</div>
+              )}
+              {vendor.phone && (
+                <div><span className="font-semibold">Telefone: </span>{vendor.phone}</div>
+              )}
+              {vendor.serviceType && (
+                <div><span className="font-semibold">Tipo de Serviço: </span>{vendor.serviceType}</div>
+              )}
+              {vendor.scope && (
+                <div><span className="font-semibold">Escopo: </span>{vendor.scope}</div>
+              )}
+              {vendor.paymentTerms && (
+                <div><span className="font-semibold">Prazo de pagamento: </span>{vendor.paymentTerms}</div>
+              )}
+              {vendor.tags && vendor.tags.length > 0 && (
+                <div><span className="font-semibold">Tags: </span>{vendor.tags.join(', ')}</div>
+              )}
+              {vendor.categories && vendor.categories.length > 0 && (
+                <div><span className="font-semibold">Categorias: </span>{vendor.categories.join(', ')}</div>
+              )}
+              {vendor.observations && (
+                <div><span className="font-semibold">Observações: </span>{vendor.observations}</div>
+              )}
+            </div>
+            <div className="mt-4">
+              <h3 className="font-semibold mb-2">Documentos</h3>
+              {docsLoading ? (
+                <div className="flex justify-center py-4">
+                  <LoadingSpinner />
+                </div>
+              ) : documents.length === 0 ? (
+                <p className="text-sm text-gray-500">Nenhum documento anexado</p>
+              ) : (
+                <ul className="list-disc pl-5 space-y-1">
+                  {documents.map((doc) => (
+                    <li key={doc.id}>
+                      <a
+                        href={doc.downloadURL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 hover:underline"
+                      >
+                        {doc.name}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+            <DialogFooter className="mt-6">
+              <button
+                onClick={() => onApprove(vendor.id)}
+                className="px-3 py-1 bg-green-600 text-white rounded-md"
+                disabled={approveDisabled}
+              >
+                Aprovar
+              </button>
+              <button
+                onClick={() => onReject(vendor.id)}
+                className="px-3 py-1 bg-red-600 text-white rounded-md"
+                disabled={rejectDisabled}
+              >
+                Reprovar
+              </button>
+              <button
+                onClick={() => onRequestInfo(vendor.id)}
+                className="px-3 py-1 bg-yellow-600 text-white rounded-md"
+                disabled={requestInfoDisabled}
+              >
+                Mais Info
+              </button>
+            </DialogFooter>
+          </>
+        ) : (
+          <div className="text-center py-12">Fornecedor não encontrado</div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default VendorDetailsModal;

--- a/src/pages/VendorApprovalsPage.jsx
+++ b/src/pages/VendorApprovalsPage.jsx
@@ -8,6 +8,7 @@ import {
 } from '@/hooks/useVendors';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { formatCNPJ, formatDate } from '@/utils';
+import VendorDetailsModal from '@/components/VendorDetailsModal';
 
 export const VendorApprovalsPage = () => {
   const { data: vendorsData, isLoading, isError } = useVendors({
@@ -19,6 +20,8 @@ export const VendorApprovalsPage = () => {
   const [sortBy, setSortBy] = useState('updatedAt');
   const [sortOrder, setSortOrder] = useState('desc');
   const navigate = useNavigate();
+  const [selectedVendorId, setSelectedVendorId] = useState('');
+  const [showDetails, setShowDetails] = useState(false);
 
   const {
     data: historyData,
@@ -75,6 +78,11 @@ export const VendorApprovalsPage = () => {
     }
   };
 
+  const openVendorDetails = (id) => {
+    setSelectedVendorId(id);
+    setShowDetails(true);
+  };
+
   return (
     <div className="space-y-6">
       <h1 className="text-3xl font-bold tracking-tight">Aprovação de Fornecedores</h1>
@@ -103,7 +111,12 @@ export const VendorApprovalsPage = () => {
                 {vendors.map((vendor) => (
                   <tr key={vendor.id} className="hover:bg-gray-50">
                     <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                      {vendor.name}
+                      <button
+                        onClick={() => openVendorDetails(vendor.id)}
+                        className="text-blue-600 hover:underline"
+                      >
+                        {vendor.name}
+                      </button>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
                       {formatCNPJ(vendor.taxId)}
@@ -210,6 +223,29 @@ export const VendorApprovalsPage = () => {
           </div>
         )}
       </div>
+      <VendorDetailsModal
+        vendorId={selectedVendorId}
+        open={showDetails}
+        onClose={() => {
+          setShowDetails(false);
+          setSelectedVendorId('');
+        }}
+        onApprove={async (id) => {
+          await handleApprove(id);
+          setShowDetails(false);
+        }}
+        onReject={async (id) => {
+          await handleReject(id);
+          setShowDetails(false);
+        }}
+        onRequestInfo={async (id) => {
+          await handleRequestInfo(id);
+          setShowDetails(false);
+        }}
+        approveDisabled={approveVendor.isPending}
+        rejectDisabled={rejectVendor.isPending}
+        requestInfoDisabled={requestInfoVendor.isPending}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- open vendor details in a modal on approval page
- include attachments and vendor info for review

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3bfd0d208832d9a8d87c49426f19d