### PR TITLE
feat: add login page and firebase auth

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
-import { signOut } from 'firebase/auth';
-import { auth } from '../services/firebase';
 import { useAuthStore } from '../stores/auth';
+import { useAuth } from '../contexts/AuthContext';
 import { useUIStore } from '../stores/ui';
 import { useUnreadNotificationsCount } from '../hooks/useNotifications';
 import { Button } from './ui/button';
@@ -19,6 +18,7 @@ import { Bell } from 'lucide-react';
 export const Header = () => {
   const { user } = useAuthStore();
   const { toggleSidebar, toggleSidebarCollapse } = useUIStore();
+  const { logout } = useAuth();
   const { data: unreadCount = 0 } = useUnreadNotificationsCount(user?.id || '');
 
   const [currentTime, setCurrentTime] = useState(new Date());
@@ -46,7 +46,7 @@ export const Header = () => {
 
   const handleLogout = async () => {
     try {
-      await signOut(auth);
+      await logout();
     } catch (error) {
       console.error('Erro ao fazer logout:', error);
     }

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { useNavigate, Navigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import { Input } from '../components/ui/input';
+import { Button } from '../components/ui/button';
+import { Card } from '../components/ui/card';
+import { Label } from '../components/ui/label';
+
+export const LoginPage = () => {
+  const { login, isAuthenticated, isLoading } = useAuth();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      await login(email, password);
+      navigate('/');
+    } catch (error) {
+      console.error(error);
+      setError('Credenciais inválidas');
+    }
+  };
+
+  if (isAuthenticated) {
+    return <Navigate to="/" replace />;
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+      <Card className="w-full max-w-sm p-6 space-y-4">
+        <h1 className="text-xl font-semibold text-center">Login</h1>
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="password">Senha</Label>
+            <Input
+              id="password"
+              type="password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </div>
+          <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading ? 'Entrando...' : 'Entrar'}
+          </Button>
+        </form>
+      </Card>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -18,12 +18,14 @@ import { ReportsPage } from '../pages/ReportsPage';
 import { useAuth } from '../contexts/AuthContext';
 import { BudgetsPage } from '../pages/BudgetsPage';
 import { ValidationPage } from '../pages/ValidationPage';
+import { LoginPage } from '../pages/LoginPage';
 
 export const AppRoutes = () => {
-  const { hasPageAccess } = useAuth();
+  const { hasPageAccess, isAuthenticated } = useAuth();
   return (
     <Routes>
-      <Route path="/" element={<Layout />}>
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/" element={isAuthenticated ? <Layout /> : <Navigate to="/login" replace />}>
         <Route index element={<Navigate to="requests" replace />} />
         <Route
           path="requests"
@@ -156,7 +158,7 @@ export const AppRoutes = () => {
           element={hasPageAccess('users') ? <UsersPage /> : <Navigate to="/" replace />}
         />
       </Route>
-      <Route path="*" element={<Navigate to="/" replace />} />
+      <Route path="*" element={<Navigate to={isAuthenticated ? '/' : '/login'} replace />} />
     </Routes>
   );
 };


### PR DESCRIPTION
## Summary
- add login page with email/password form
- integrate Firebase auth in context and routes
- wire logout button to sign out via context

## Testing
- `pnpm lint`
- `pnpm run test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c9bb0cc8832d9e84e691183079b9