### PR TITLE
feat: add return status and resubmission flow

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -19,6 +19,7 @@ export const ROLES = {
 // Status das solicitações
 export const REQUEST_STATUS = {
   PENDING_VALIDATION: 'pending_validation',
+  RETURNED: 'returned',
   PENDING_OWNER_APPROVAL: 'pending_owner_approval',
   PENDING_FPA_APPROVAL: 'pending_fpa_approval',
   PENDING_DIRECTOR_APPROVAL: 'pending_director_approval',
@@ -64,6 +65,7 @@ export const ROLE_LABELS = {
 
 export const STATUS_LABELS = {
   [REQUEST_STATUS.PENDING_VALIDATION]: 'Ag. validação',
+  [REQUEST_STATUS.RETURNED]: 'Devolvida',
   [REQUEST_STATUS.PENDING_OWNER_APPROVAL]: 'Ag. aprovação do owner',
   [REQUEST_STATUS.PENDING_FPA_APPROVAL]: 'Ag. aprovação FP&A',
   [REQUEST_STATUS.PENDING_DIRECTOR_APPROVAL]: 'Ag. aprovação Diretor',
@@ -96,6 +98,7 @@ export const DOCUMENT_TYPE_LABELS = {
 // Cores para status
 export const STATUS_COLORS = {
   [REQUEST_STATUS.PENDING_VALIDATION]: 'orange',
+  [REQUEST_STATUS.RETURNED]: 'cyan',
   [REQUEST_STATUS.PENDING_OWNER_APPROVAL]: 'yellow',
   [REQUEST_STATUS.PENDING_FPA_APPROVAL]: 'purple',
   [REQUEST_STATUS.PENDING_DIRECTOR_APPROVAL]: 'indigo',

--- a/src/hooks/useRequests.ts
+++ b/src/hooks/useRequests.ts
@@ -161,7 +161,10 @@ export const useSubmitRequest = () => {
       // Invalidar queries relacionadas
       queryClient.invalidateQueries({ queryKey: queryKeys.requests });
       queryClient.invalidateQueries({ queryKey: queryKeys.request(id) });
-      
+      queryClient.invalidateQueries({ queryKey: queryKeys.requestsByStatus('returned') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.requestsByStatus('pending_validation') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.requestsByStatus('pending_owner_approval') });
+
       success('Solicitação enviada para aprovação!');
     },
     onError: (err: any) => {
@@ -200,6 +203,39 @@ export const useValidateRequest = () => {
     onError: (err: any) => {
       console.error('Erro ao validar solicitação:', err);
       error('Erro ao validar solicitação', err.message || 'Tente novamente.');
+    },
+  });
+};
+
+// Hook para devolver solicitação ao colaborador
+export const useReturnRequest = () => {
+  const queryClient = useQueryClient();
+  const { success, error } = useNotifications();
+
+  return useMutation({
+    mutationFn: ({
+      id,
+      validatorId,
+      validatorName,
+      reason,
+    }: {
+      id: string;
+      validatorId: string;
+      validatorName: string;
+      reason: string;
+    }) => requestsService.returnRequest(id, validatorId, validatorName, reason),
+    onSuccess: (_, { id }) => {
+      // Invalidar queries relacionadas
+      queryClient.invalidateQueries({ queryKey: queryKeys.requests });
+      queryClient.invalidateQueries({ queryKey: queryKeys.request(id) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.requestsByStatus('pending_validation') });
+      queryClient.invalidateQueries({ queryKey: queryKeys.requestsByStatus('returned') });
+
+      success('Solicitação devolvida para ajustes.');
+    },
+    onError: (err: any) => {
+      console.error('Erro ao devolver solicitação:', err);
+      error('Erro ao devolver solicitação', err.message || 'Tente novamente.');
     },
   });
 };

--- a/src/pages/ValidationPage.jsx
+++ b/src/pages/ValidationPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useAuth } from '../contexts/AuthContext';
-import { useRequestsByStatus, useValidateRequest, useRejectRequest } from '../hooks/useRequests';
+import { useRequestsByStatus, useValidateRequest, useReturnRequest } from '../hooks/useRequests';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { formatCurrency } from '@/utils';
 
@@ -8,7 +8,7 @@ export const ValidationPage = () => {
   const { user } = useAuth();
   const { data, isLoading, isError } = useRequestsByStatus('pending_validation');
   const validateRequest = useValidateRequest();
-  const rejectRequest = useRejectRequest();
+  const returnRequest = useReturnRequest();
 
   const requests = data || [];
 
@@ -25,10 +25,10 @@ export const ValidationPage = () => {
   const handleReturn = (id) => {
     const reason = window.prompt('Motivo da devolução');
     if (!reason) return;
-    rejectRequest.mutate({
+    returnRequest.mutate({
       id,
-      approverId: user.id,
-      approverName: user.name,
+      validatorId: user.id,
+      validatorName: user.name,
       reason,
     });
   };
@@ -82,7 +82,7 @@ export const ValidationPage = () => {
                       <button
                         onClick={() => handleReturn(req.id)}
                         className="px-3 py-1 bg-red-600 text-white rounded-md"
-                        disabled={rejectRequest.isPending}
+                        disabled={returnRequest.isPending}
                       >
                         Devolver
                       </button>

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -269,6 +269,7 @@ export const getRequestsByStatus = async (
     
     const statusLabels = {
       pending_validation: 'Ag. validação',
+      returned: 'Devolvido',
       pending_owner_approval: 'Ag. aprovação do owner',
       pending_fpa_approval: 'Ag. aprovação FP&A',
       pending_director_approval: 'Ag. aprovação Diretor',
@@ -282,6 +283,7 @@ export const getRequestsByStatus = async (
 
     const statusColors = {
       pending_validation: '#fb923c',
+      returned: '#06b6d4',
       pending_owner_approval: '#f59e0b',
       pending_fpa_approval: '#a855f7',
       pending_director_approval: '#6366f1',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,7 @@ export type Role =
 
 export type RequestStatus =
   | 'pending_validation'
+  | 'returned'
   | 'pending_owner_approval'
   | 'pending_fpa_approval'
   | 'pending_director_approval'


### PR DESCRIPTION
## Summary
- add `returned` status constants and analytics support
- implement `returnRequest` service/hook and use in validation page
- resubmit returned requests through `submitRequest`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3cbbcfaf0832d8f94008928f744e2