### PR TITLE
feat: sync vendors and employees with SAP

### DIFF
--- a/src/services/sap.ts
+++ b/src/services/sap.ts
@@ -1,4 +1,4 @@
-import type { Vendor } from '../types';
+import type { Vendor, User } from '../types';
 
 const API_URL = import.meta.env.VITE_SAP_API_URL || 'https://sap.example.com/api';
 const API_TOKEN = import.meta.env.VITE_SAP_API_TOKEN || '';
@@ -28,4 +28,29 @@ export const createOrUpdateVendor = async (
   }
 };
 
-export default { createOrUpdateVendor };
+export const createOrUpdateEmployee = async (
+  employee: Pick<User, 'id' | 'name' | 'email'> & { taxId?: string; phone?: string },
+): Promise<string> => {
+  try {
+    const resp = await fetch(`${API_URL}/employees`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${API_TOKEN}`,
+      },
+      body: JSON.stringify(employee),
+    });
+
+    if (!resp.ok) {
+      throw new Error('Falha ao sincronizar funcionário no SAP');
+    }
+
+    const data = await resp.json();
+    return data.id || data.employeeId || '';
+  } catch (error) {
+    console.error('Erro ao integrar com SAP:', error);
+    throw error;
+  }
+};
+
+export default { createOrUpdateVendor, createOrUpdateEmployee };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -124,6 +124,8 @@ export interface PaymentRequest {
   categoryId: string;
   vendorId: string;
   vendorName?: string;
+  sapVendorId?: string;
+  sapEmployeeId?: string;
   invoiceNumber?: string;
   requestNumber?: string;
   dueDate: Date;


### PR DESCRIPTION
## Summary
- integrate SAP employee sync alongside vendor sync
- sync and persist SAP IDs when validating or approving requests
- add storage for SAP vendor/employee IDs on payment requests

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3cbc02cf0832db93099ad2f7c52e1