### PR TITLE
Add admin user with full access

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -7,6 +7,7 @@ export const CURRENCY = 'BRL';
 
 // Papéis do sistema
 export const ROLES = {
+  ADMIN: 'admin',
   USER: 'user',
   COST_CENTER_OWNER: 'cost_center_owner',
   FINANCE: 'finance',
@@ -56,6 +57,7 @@ export const DOCUMENT_TYPES = {
 
 // Labels para exibição
 export const ROLE_LABELS = {
+  [ROLES.ADMIN]: 'Administrador',
   [ROLES.USER]: 'Usuário',
   [ROLES.COST_CENTER_OWNER]: 'Dono de Centro de Custos',
   [ROLES.FINANCE]: 'Financeiro',

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -107,6 +107,7 @@ export const AuthProvider = ({ children }) => {
     const roles = currentUser?.roles || (currentUser?.role ? [currentUser.role] : []);
     return (
       roles.includes('finance') ||
+      roles.includes('admin') ||
       roles.some((role) => permissions[page]?.includes(role))
     );
   };
@@ -135,11 +136,11 @@ export const AuthProvider = ({ children }) => {
     logout,
     hasRole: (role) => {
       const roles = currentUser?.roles || (currentUser?.role ? [currentUser.role] : []);
-      return roles.includes(role) || roles.includes('finance');
+      return roles.includes(role) || roles.includes('finance') || roles.includes('admin');
     },
     hasAnyRole: (rolesToCheck) => {
       const roles = currentUser?.roles || (currentUser?.role ? [currentUser.role] : []);
-      return roles.includes('finance') || rolesToCheck.some((r) => roles.includes(r));
+      return roles.includes('finance') || roles.includes('admin') || rolesToCheck.some((r) => roles.includes(r));
     },
   };
 

--- a/src/utils/seedData.js
+++ b/src/utils/seedData.js
@@ -34,6 +34,18 @@ export const seedUsers = [
     updatedAt: serverTimestamp(),
   },
   {
+    id: 'admin-002',
+    name: 'Lucas Augusto Santos',
+    email: 'lucasaugusto2santos@gmail.com',
+    role: 'admin',
+    active: true,
+    phone: '(11) 99999-0008',
+    approvalLimit: 1000000,
+    costCenters: [],
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+  },
+  {
     id: 'finance-001',
     name: 'Maria Santos',
     email: 'maria.santos@empresa.com',


### PR DESCRIPTION
## Summary
- add ADMIN role constant and label
- allow admin role to access any page
- seed admin user lucasaugusto2santos@gmail.com

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a44aad160c832d94ca416a24f68768