### PR TITLE
Allow system access for all roles

### DIFF
--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -118,14 +118,8 @@ export const AuthProvider = ({ children }) => {
     setPermissions((prev) => ({ ...prev, [page]: roles }));
   };
 
-  const hasPageAccess = (page) => {
-    const roles = currentUser?.roles ?? [];
-    return (
-      roles.includes('finance') ||
-      roles.includes('admin') ||
-      roles.some((role) => permissions[page]?.includes(role))
-    );
-  };
+  // Temporarily allow access to all pages for every role
+  const hasPageAccess = () => true;
 
   const login = (email, password) => {
     setIsLoading(true);
@@ -149,14 +143,8 @@ export const AuthProvider = ({ children }) => {
     isLoading,
     login,
     logout,
-    hasRole: (role) => {
-      const roles = currentUser?.roles ?? [];
-      return roles.includes(role) || roles.includes('finance') || roles.includes('admin');
-    },
-    hasAnyRole: (rolesToCheck) => {
-      const roles = currentUser?.roles ?? [];
-      return roles.includes('finance') || roles.includes('admin') || rolesToCheck.some((r) => roles.includes(r));
-    },
+    hasRole: () => true,
+    hasAnyRole: () => true,
   };
 
   return <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>;

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -57,51 +57,16 @@ export const useAuthStore = create<AuthState>()(
         error: null 
       }),
       
-      // Verificações de permissão
-      hasRole: (role) => {
-        const { user } = get();
-        return user?.roles.includes(role as any) ?? false;
-      },
-      
-      hasAnyRole: (roles) => {
-        const { user } = get();
-        if (!user) return false;
-        return roles.some(role => user.roles.includes(role as any));
-      },
-      
-      canApprove: (costCenterId) => {
-        const { user } = get();
-        if (!user) return false;
+      // Temporarily allow all permissions for every role
+      hasRole: () => true,
 
-        // Finance pode aprovar qualquer solicitação
-        if (user.roles.includes('finance')) {
-          return true;
-        }
+      hasAnyRole: () => true,
 
-        // Dono de centro de custos pode aprovar solicitações do seu centro
-        if (user.roles.includes('cost_center_owner')) {
-          if (!costCenterId) return true;
-          return user.ccScope.includes(costCenterId);
-        }
+      canApprove: () => true,
 
-        return false;
-      },
+      canManageCostCenter: () => true,
 
-      canManageCostCenter: (costCenterId) => {
-        const { user } = get();
-        if (!user) return false;
-
-        // Finance pode gerenciar qualquer centro de custo
-        if (user.roles.includes('finance')) return true;
-
-        // Dono de centro de custos pode gerenciar se está no escopo
-        return user.ccScope.includes(costCenterId);
-      },
-
-      isFinance: () => {
-        const { user } = get();
-        return user?.roles.includes('finance') ?? false;
-      },
+      isFinance: () => true,
     }),
     {
       name: 'auth-storage',


### PR DESCRIPTION
## Summary
- bypass page access checks so all roles can navigate the system
- always grant role-based permissions in auth store

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a4543ea94c832da026bb5ec4e052e7