### PR TITLE
feat: add budget request flow

### DIFF
--- a/src/components/BudgetRequestDetailsModal.jsx
+++ b/src/components/BudgetRequestDetailsModal.jsx
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from './ui/dialog';
+import { Input } from './ui/input';
+import { Textarea } from './ui/textarea';
+import { Button } from './ui/button';
+import { useBudgetRequests } from '@/stores/budget-requests';
+
+const BudgetRequestDetailsModal = ({ request, open, onClose }) => {
+  const updateStatus = useBudgetRequests((s) => s.updateStatus);
+  const addComment = useBudgetRequests((s) => s.addComment);
+  const addBudget = useBudgetRequests((s) => s.addBudget);
+  const selectBudget = useBudgetRequests((s) => s.selectBudget);
+
+  const [comment, setComment] = useState('');
+  const [budgetForm, setBudgetForm] = useState({
+    supplierName: '',
+    cnpj: '',
+    value: '',
+    paymentMethod: '',
+    paymentTerms: '',
+    attachment: null,
+  });
+  const [selected, setSelected] = useState(null);
+  const [reason, setReason] = useState('');
+
+  if (!request) return null;
+
+  const handleAddComment = () => {
+    if (comment.trim()) {
+      addComment(request.id, comment.trim());
+      setComment('');
+    }
+  };
+
+  const handleAddBudget = () => {
+    if (request.budgets.length >= 3) return;
+    addBudget(request.id, {
+      supplierName: budgetForm.supplierName,
+      cnpj: budgetForm.cnpj,
+      value: parseFloat(budgetForm.value) || 0,
+      paymentMethod: budgetForm.paymentMethod,
+      paymentTerms: budgetForm.paymentTerms,
+      attachment: budgetForm.attachment,
+    });
+    setBudgetForm({ supplierName: '', cnpj: '', value: '', paymentMethod: '', paymentTerms: '', attachment: null });
+  };
+
+  const handleApprove = () => {
+    if (selected === null) return;
+    selectBudget(request.id, selected, reason);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-2xl space-y-4">
+        <DialogHeader>
+          <DialogTitle>Detalhes {request.id}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div>
+            <h3 className="font-medium">Comentários</h3>
+            <ul className="mb-2 list-disc list-inside">
+              {request.comments.map((c, i) => (
+                <li key={i}>{c}</li>
+              ))}
+            </ul>
+            <div className="flex space-x-2">
+              <Input value={comment} onChange={(e) => setComment(e.target.value)} placeholder="Novo comentário" />
+              <Button type="button" onClick={handleAddComment}>Adicionar</Button>
+            </div>
+          </div>
+          <div>
+            <h3 className="font-medium mb-2">Orçamentos</h3>
+            {request.budgets.map((b, i) => (
+              <div key={i} className="border p-2 rounded mb-2 flex flex-col space-y-1">
+                <div className="flex items-center space-x-2">
+                  <input type="radio" name="winner" checked={selected === i} onChange={() => setSelected(i)} />
+                  <span className="font-medium">{`Orçamento ${i + 1}`}</span>
+                </div>
+                <span>Fornecedor: {b.supplierName}</span>
+                <span>CNPJ: {b.cnpj}</span>
+                <span>Valor: {b.value}</span>
+                <span>Forma de pagamento: {b.paymentMethod}</span>
+                <span>Prazo de pagamento: {b.paymentTerms}</span>
+              </div>
+            ))}
+            {request.budgets.length < 3 && (
+              <div className="border p-2 rounded space-y-2">
+                <Input placeholder="Fornecedor" value={budgetForm.supplierName} onChange={(e) => setBudgetForm({ ...budgetForm, supplierName: e.target.value })} />
+                <Input placeholder="CNPJ" value={budgetForm.cnpj} onChange={(e) => setBudgetForm({ ...budgetForm, cnpj: e.target.value })} />
+                <Input placeholder="Valor" value={budgetForm.value} onChange={(e) => setBudgetForm({ ...budgetForm, value: e.target.value })} />
+                <Input placeholder="Forma de pagamento" value={budgetForm.paymentMethod} onChange={(e) => setBudgetForm({ ...budgetForm, paymentMethod: e.target.value })} />
+                <Input placeholder="Prazo de pagamento" value={budgetForm.paymentTerms} onChange={(e) => setBudgetForm({ ...budgetForm, paymentTerms: e.target.value })} />
+                <Input type="file" onChange={(e) => setBudgetForm({ ...budgetForm, attachment: e.target.files?.[0] || null })} />
+                <Button type="button" onClick={handleAddBudget}>Adicionar Orçamento</Button>
+              </div>
+            )}
+          </div>
+          {request.status !== 'Aprovado' && (
+            <div className="space-y-2">
+              <h3 className="font-medium">Seleção do vencedor</h3>
+              <Textarea placeholder="Motivo" value={reason} onChange={(e) => setReason(e.target.value)} />
+              <Button type="button" onClick={handleApprove} disabled={selected === null}>
+                Aprovar
+              </Button>
+            </div>
+          )}
+          {request.status === 'Pendente' && (
+            <Button type="button" onClick={() => updateStatus(request.id, 'Em Andamento')}>Marcar como Em Andamento</Button>
+          )}
+        </div>
+        <DialogFooter>
+          <Button type="button" onClick={onClose}>Fechar</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default BudgetRequestDetailsModal;
+

--- a/src/components/BudgetRequestModal.jsx
+++ b/src/components/BudgetRequestModal.jsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from './ui/dialog';
+import { Input } from './ui/input';
+import { Textarea } from './ui/textarea';
+import { Checkbox } from './ui/checkbox';
+import { Button } from './ui/button';
+import { useBudgetRequests } from '@/stores/budget-requests';
+
+const BudgetRequestModal = ({ open, onClose }) => {
+  const addRequest = useBudgetRequests((s) => s.addRequest);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [explanation, setExplanation] = useState('');
+  const [inBudget, setInBudget] = useState(false);
+  const [budgetLine, setBudgetLine] = useState('');
+  const [attachments, setAttachments] = useState([]);
+  const [supplierSuggestions, setSupplierSuggestions] = useState('');
+
+  const reset = () => {
+    setTitle('');
+    setDescription('');
+    setExplanation('');
+    setInBudget(false);
+    setBudgetLine('');
+    setAttachments([]);
+    setSupplierSuggestions('');
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    addRequest({
+      title,
+      description,
+      explanation: inBudget ? '' : explanation,
+      inBudget,
+      budgetLine: inBudget ? budgetLine : '',
+      attachments,
+      supplierSuggestions,
+    });
+    reset();
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Solicitar Orçamento</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium">Título</label>
+            <Input value={title} onChange={(e) => setTitle(e.target.value)} required />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Descrição</label>
+            <Textarea value={description} onChange={(e) => setDescription(e.target.value)} required />
+          </div>
+          <div className="flex items-center space-x-2">
+            <Checkbox checked={inBudget} onCheckedChange={(v) => setInBudget(!!v)} id="inBudget" />
+            <label htmlFor="inBudget" className="text-sm">Está em orçamento?</label>
+          </div>
+          {inBudget ? (
+            <div>
+              <label className="block text-sm font-medium">Linha de orçamento</label>
+              <Input value={budgetLine} onChange={(e) => setBudgetLine(e.target.value)} />
+            </div>
+          ) : (
+            <div>
+              <label className="block text-sm font-medium">Explicação</label>
+              <Textarea value={explanation} onChange={(e) => setExplanation(e.target.value)} />
+            </div>
+          )}
+          <div>
+            <label className="block text-sm font-medium">Anexos</label>
+            <Input type="file" multiple onChange={(e) => setAttachments(Array.from(e.target.files || []))} />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Sugestão de fornecedores</label>
+            <Textarea value={supplierSuggestions} onChange={(e) => setSupplierSuggestions(e.target.value)} />
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose}>Cancelar</Button>
+            <Button type="submit">Enviar</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default BudgetRequestModal;
+

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -20,6 +20,7 @@ const navigation = [
   { name: 'Pagamentos', href: '/payments', icon: '💳', page: 'payments' },
   { name: 'Relatórios', href: '/reports', icon: '📊', page: 'reports' },
   { name: 'Orçamento', href: '/budgets', icon: '🗓️', page: 'budgets' },
+  { name: 'Solic. Orçamentos', href: '/budget-requests', icon: '📄', page: 'budgetRequests' },
   { name: 'Usuários', href: '/users', icon: '👥', page: 'users' },
 ];
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -229,6 +229,7 @@ export const ROUTES = {
   POLICIES: '/policies',
   DOCUMENTS: '/documents',
   REPORTS: '/reports',
+  BUDGET_REQUESTS: '/budget-requests',
   ADMIN: '/admin',
   AUDIT: '/admin/audit',
   PROFILE: '/profile',

--- a/src/pages/BudgetRequestsPage.jsx
+++ b/src/pages/BudgetRequestsPage.jsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { useBudgetRequests } from '@/stores/budget-requests';
+import BudgetRequestDetailsModal from '@/components/BudgetRequestDetailsModal';
+
+export const BudgetRequestsPage = () => {
+  const { requests } = useBudgetRequests();
+  const [selected, setSelected] = useState(null);
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold tracking-tight">Solicitações de Orçamento</h1>
+      <table className="min-w-full bg-white border">
+        <thead>
+          <tr className="bg-gray-50">
+            <th className="px-4 py-2 text-left">ID</th>
+            <th className="px-4 py-2 text-left">Título</th>
+            <th className="px-4 py-2 text-left">Status</th>
+            <th className="px-4 py-2">Ações</th>
+          </tr>
+        </thead>
+        <tbody>
+          {requests.map((r) => (
+            <tr key={r.id} className="border-t">
+              <td className="px-4 py-2">{r.id}</td>
+              <td className="px-4 py-2">{r.title}</td>
+              <td className="px-4 py-2">{r.status}</td>
+              <td className="px-4 py-2 text-center">
+                <button
+                  className="text-blue-600 hover:underline"
+                  onClick={() => setSelected(r)}
+                >
+                  Detalhes
+                </button>
+              </td>
+            </tr>
+          ))}
+          {requests.length === 0 && (
+            <tr>
+              <td colSpan={4} className="px-4 py-8 text-center text-gray-500">
+                Nenhuma solicitação registrada
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+      <BudgetRequestDetailsModal
+        request={selected}
+        open={!!selected}
+        onClose={() => setSelected(null)}
+      />
+    </div>
+  );
+};
+
+export default BudgetRequestsPage;
+

--- a/src/pages/RequestsPage.jsx
+++ b/src/pages/RequestsPage.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Plus, Search, Edit, Eye, CheckCircle, XCircle, Clock, DollarSign } from 'lucide-react';
+import BudgetRequestModal from '../components/BudgetRequestModal';
+import { useBudgetRequests } from '../stores/budget-requests';
 import { useRequestsList, useRequestStats, useApproveRequest, useRejectRequest } from '../hooks/useRequests';
 import { useAuth } from '../contexts/AuthContext';
 import { useNotifications } from '../stores/ui';
@@ -19,6 +21,8 @@ export const RequestsPage = () => {
   const approveRequest = useApproveRequest();
   const rejectRequest = useRejectRequest();
   const { error: notifyError } = useNotifications();
+  const { requests: budgetRequests } = useBudgetRequests();
+  const [showBudgetModal, setShowBudgetModal] = useState(false);
   const { data, isLoading, isError, error } = useRequestsList({
     page,
     limit,
@@ -170,13 +174,22 @@ export const RequestsPage = () => {
             Gerencie todas as solicitações de pagamento da empresa
           </p>
         </div>
-        <button
-          onClick={() => setShowNewRequest(true)}
-          className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
-        >
-          <Plus className="w-4 h-4 mr-2" />
-          Nova Solicitação
-        </button>
+        <div className="flex space-x-2">
+          <button
+            onClick={() => setShowBudgetModal(true)}
+            className="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 transition-colors"
+          >
+            <Plus className="w-4 h-4 mr-2" />
+            Solicitar Orçamento
+          </button>
+          <button
+            onClick={() => setShowNewRequest(true)}
+            className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+          >
+            <Plus className="w-4 h-4 mr-2" />
+            Nova Solicitação
+          </button>
+        </div>
       </div>
 
       {/* Estatísticas */}
@@ -497,6 +510,36 @@ export const RequestsPage = () => {
         )}
       </div>
 
+      {/* Solicitações de Orçamento */}
+      <div className="mt-10">
+        <h2 className="text-xl font-bold mb-2">Solicitações de Orçamento</h2>
+        <table className="min-w-full bg-white border">
+          <thead>
+            <tr className="bg-gray-50">
+              <th className="px-4 py-2 text-left">ID</th>
+              <th className="px-4 py-2 text-left">Título</th>
+              <th className="px-4 py-2 text-left">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {budgetRequests.map((r) => (
+              <tr key={r.id} className="border-t">
+                <td className="px-4 py-2">{r.id}</td>
+                <td className="px-4 py-2">{r.title}</td>
+                <td className="px-4 py-2">{r.status}</td>
+              </tr>
+            ))}
+            {budgetRequests.length === 0 && (
+              <tr>
+                <td colSpan={3} className="px-4 py-8 text-center text-gray-500">
+                  Nenhuma solicitação de orçamento
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
       {/* Paginação */}
       <div className="flex items-center justify-between">
         <div className="text-sm text-gray-700">
@@ -520,6 +563,7 @@ export const RequestsPage = () => {
         </div>
       </div>
       <NewRequestModal open={showNewRequest} onClose={() => setShowNewRequest(false)} />
+      <BudgetRequestModal open={showBudgetModal} onClose={() => setShowBudgetModal(false)} />
     </div>
   );
 };

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -17,6 +17,7 @@ import { PaymentManagementPage } from '../pages/PaymentManagementPage';
 import { ReportsPage } from '../pages/ReportsPage';
 import { useAuth } from '../contexts/AuthContext';
 import { BudgetsPage } from '../pages/BudgetsPage';
+import { BudgetRequestsPage } from '../pages/BudgetRequestsPage';
 import { ValidationPage } from '../pages/ValidationPage';
 import { AccountingMonitorPage } from '../pages/AccountingMonitorPage';
 import { LoginPage } from '../pages/LoginPage';
@@ -159,6 +160,16 @@ export const AppRoutes = () => {
           element={
             hasPageAccess('budgets') ? (
               <BudgetsPage />
+            ) : (
+              <Navigate to="/" replace />
+            )
+          }
+        />
+        <Route
+          path="budget-requests"
+          element={
+            hasPageAccess('budgetRequests') ? (
+              <BudgetRequestsPage />
             ) : (
               <Navigate to="/" replace />
             )

--- a/src/stores/budget-requests.ts
+++ b/src/stores/budget-requests.ts
@@ -1,0 +1,85 @@
+import { create } from 'zustand';
+
+export interface BudgetLineSelection {
+  title: string;
+  description: string;
+  explanation: string;
+  inBudget: boolean;
+  budgetLine: string;
+  attachments: File[];
+  supplierSuggestions: string;
+}
+
+export interface BudgetItem {
+  supplierName: string;
+  cnpj: string;
+  attachment?: File | null;
+  value: number;
+  paymentMethod: string;
+  paymentTerms: string;
+}
+
+export interface BudgetRequest extends BudgetLineSelection {
+  id: string;
+  status: 'Pendente' | 'Em Andamento' | 'Aprovado';
+  comments: string[];
+  budgets: BudgetItem[];
+  selectedBudget?: number;
+  selectionReason?: string;
+}
+
+interface BudgetRequestState {
+  requests: BudgetRequest[];
+  counter: number;
+  addRequest: (data: BudgetLineSelection) => void;
+  updateStatus: (id: string, status: BudgetRequest['status']) => void;
+  addComment: (id: string, comment: string) => void;
+  addBudget: (id: string, budget: BudgetItem) => void;
+  selectBudget: (id: string, index: number, reason: string) => void;
+}
+
+export const useBudgetRequests = create<BudgetRequestState>((set) => ({
+  requests: [],
+  counter: 1,
+  addRequest: (data) =>
+    set((state) => ({
+      requests: [
+        ...state.requests,
+        {
+          id: `BID-${String(state.counter).padStart(4, '0')}`,
+          status: 'Pendente',
+          comments: [],
+          budgets: [],
+          ...data,
+        },
+      ],
+      counter: state.counter + 1,
+    })),
+  updateStatus: (id, status) =>
+    set((state) => ({
+      requests: state.requests.map((r) =>
+        r.id === id ? { ...r, status } : r
+      ),
+    })),
+  addComment: (id, comment) =>
+    set((state) => ({
+      requests: state.requests.map((r) =>
+        r.id === id ? { ...r, comments: [...r.comments, comment] } : r
+      ),
+    })),
+  addBudget: (id, budget) =>
+    set((state) => ({
+      requests: state.requests.map((r) =>
+        r.id === id ? { ...r, budgets: [...r.budgets, budget] } : r
+      ),
+    })),
+  selectBudget: (id, index, reason) =>
+    set((state) => ({
+      requests: state.requests.map((r) =>
+        r.id === id
+          ? { ...r, selectedBudget: index, selectionReason: reason, status: 'Aprovado' }
+          : r
+      ),
+    })),
+}));
+


### PR DESCRIPTION
## Summary
- add modal to request budgets and list them on Requests page
- create budget requests page with detailed handling and approvals
- implement store for budget requests and navigation entry

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6e61d4fb4832d8ede66ec3759b247