### PR TITLE
Restrict user role access to permitted pages and personal requests

### DIFF
--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -146,8 +146,11 @@ export const AuthProvider = ({ children }) => {
     setPermissions((prev) => ({ ...prev, [page]: roles }));
   };
 
-  // Temporarily allow access to all pages for every role
-  const hasPageAccess = () => true;
+  const hasPageAccess = (page) => {
+    if (!currentUser) return false;
+    const allowedRoles = permissions[page] || [];
+    return currentUser.roles?.some((role) => allowedRoles.includes(role));
+  };
 
   const login = (email, password) => {
     setIsLoading(true);
@@ -171,8 +174,8 @@ export const AuthProvider = ({ children }) => {
     isLoading,
     login,
     logout,
-    hasRole: () => true,
-    hasAnyRole: () => true,
+    hasRole: (role) => currentUser?.roles?.includes(role),
+    hasAnyRole: (roles) => currentUser?.roles?.some((r) => roles.includes(r)),
   };
 
   return <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>;

--- a/src/hooks/useRequests.ts
+++ b/src/hooks/useRequests.ts
@@ -25,6 +25,7 @@ export const useRequestsList = (
     vendorId?: string;
     costCenterId?: string;
     categoryId?: string;
+    requesterId?: string;
     orderBy?: 'createdAt' | 'dueDate' | 'amount' | 'status' | 'priority';
     orderDir?: 'asc' | 'desc';
     minAmount?: number;
@@ -45,6 +46,7 @@ export const useRequestsList = (
         costCenterId: params.costCenterId,
         categoryId: params.categoryId,
         search: params.search,
+        requesterId: params.requesterId,
         dateFrom: params.fromDate,
         dateTo: params.toDate,
         amountFrom: params.minAmount,
@@ -97,6 +99,7 @@ export const useRequestStats = (
     dateTo?: Date;
     costCenterId?: string;
     categoryId?: string;
+    requesterId?: string;
   } = {}
 ) => {
   return useQuery({

--- a/src/pages/RequestsPage.jsx
+++ b/src/pages/RequestsPage.jsx
@@ -25,6 +25,7 @@ export const RequestsPage = () => {
   const { error: notifyError } = useNotifications();
   const { requests: budgetRequests } = useBudgetRequests();
   const [showBudgetModal, setShowBudgetModal] = useState(false);
+  const isBasicUser = user?.roles?.includes('user');
   const { data, isLoading, isError, error } = useRequestsList({
     page,
     limit,
@@ -32,8 +33,11 @@ export const RequestsPage = () => {
     status: statusFilter || undefined,
     orderBy,
     orderDir,
+    requesterId: isBasicUser ? user.id : undefined,
   });
-  const { data: stats } = useRequestStats();
+  const { data: stats } = useRequestStats(
+    isBasicUser ? { requesterId: user.id } : {},
+  );
   const requests = data?.data || [];
   const total = data?.total || 0;
   const totalPages = data?.totalPages || 1;

--- a/src/services/requests.ts
+++ b/src/services/requests.ts
@@ -1165,6 +1165,7 @@ export const getRequestStats = async (
     dateTo?: Date;
     costCenterId?: string;
     categoryId?: string;
+    requesterId?: string;
   } = {}
 ): Promise<{
   total: number;
@@ -1183,6 +1184,10 @@ export const getRequestStats = async (
 
     if (filters.categoryId) {
       q = query(q, where('categoryId', '==', filters.categoryId));
+    }
+
+    if (filters.requesterId) {
+      q = query(q, where('requesterId', '==', filters.requesterId));
     }
 
     const snapshot = await getDocs(q);

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -57,10 +57,15 @@ export const useAuthStore = create<AuthState>()(
         error: null 
       }),
       
-      // Temporarily allow all permissions for every role
-      hasRole: () => true,
+      hasRole: (role: string) => {
+        const user = get().user;
+        return user?.roles?.includes(role);
+      },
 
-      hasAnyRole: () => true,
+      hasAnyRole: (roles: string[]) => {
+        const user = get().user;
+        return user?.roles?.some((r) => roles.includes(r));
+      },
 
       canApprove: () => true,
 


### PR DESCRIPTION
## Summary
- enforce role-based page permissions and role helpers
- filter requests and stats by requester so users see only their entries

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7361fc0b4832db51a0edf78c5e1c1