### PR TITLE
fix: display owner pending requests without cc scope

### DIFF
--- a/src/pages/OwnerApprovalsPage.jsx
+++ b/src/pages/OwnerApprovalsPage.jsx
@@ -28,11 +28,14 @@ export const OwnerApprovalsPage = () => {
   const rejectRequest = useRejectRequest();
 
   const userCostCenters = user?.ccScope ?? user?.costCenters ?? [];
-  const pendingRequests = (pendingData ?? []).filter((r) =>
-    userCostCenters.includes(r.costCenterId)
+  const pendingRequests = (pendingData ?? []).filter(
+    (r) =>
+      userCostCenters.length === 0 || userCostCenters.includes(r.costCenterId)
   );
   const historyRequests = (historyData?.data ?? []).filter(
-    (r) => userCostCenters.includes(r.costCenterId) && r.status !== 'pending_owner_approval'
+    (r) =>
+      (userCostCenters.length === 0 || userCostCenters.includes(r.costCenterId)) &&
+      r.status !== 'pending_owner_approval'
   );
 
   const filteredHistory = historyRequests.filter((r) => {


### PR DESCRIPTION
## Summary
- display owner pending requests even when user has no cost center scope

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a75fc0c0ac832da8e6cc4812885042