### PR TITLE
refactor: remove budget field from cost center creation

### DIFF
--- a/src/pages/CostCentersPage.jsx
+++ b/src/pages/CostCentersPage.jsx
@@ -6,7 +6,7 @@ export const CostCentersPage = () => {
   const [costCenters, setCostCenters] = useState([]);
   const [loading, setLoading] = useState(true);
   const [showModal, setShowModal] = useState(false);
-  const [form, setForm] = useState({ name: '', managerId: '', directorId: '', budget: 0 });
+  const [form, setForm] = useState({ name: '', managerId: '', directorId: '' });
   const { users } = useAuth();
 
   const fetchCostCenters = async () => {
@@ -35,11 +35,10 @@ export const CostCentersPage = () => {
       await createCostCenter({
         name: form.name,
         managerId: form.managerId,
-        directorId: form.directorId,
-        budget: Number(form.budget)
+        directorId: form.directorId
       });
       setShowModal(false);
-      setForm({ name: '', managerId: '', directorId: '', budget: 0 });
+      setForm({ name: '', managerId: '', directorId: '' });
       fetchCostCenters();
     } catch (error) {
       console.error('Erro ao criar centro de custo:', error);
@@ -157,18 +156,6 @@ export const CostCentersPage = () => {
                     </option>
                   ))}
                 </select>
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700">Orçamento</label>
-                <input
-                  name="budget"
-                  type="number"
-                  min="0"
-                  value={form.budget}
-                  onChange={handleChange}
-                  className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                  required
-                />
               </div>
               <div className="flex justify-end space-x-2">
                 <button

--- a/src/services/costCenters.ts
+++ b/src/services/costCenters.ts
@@ -138,7 +138,6 @@ export const createCostCenter = async (ccData: {
   managerId: string;
   directorId: string;
   parentId?: string;
-  budget?: number;
 }): Promise<CostCenter> => {
   try {
     const code = await generateCostCenterCode();
@@ -149,7 +148,6 @@ export const createCostCenter = async (ccData: {
       managerId: ccData.managerId,
       directorId: ccData.directorId,
       parentId: ccData.parentId || null,
-      budget: ccData.budget || 0,
       spent: 0,
       committed: 0,
       status: 'active',


### PR DESCRIPTION
## Summary
- remove budget input from cost center creation form
- drop budget parameter from createCostCenter service

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a763fc8e54832d9c0079cd34102882