### PR TITLE
feat: link expenses to budget lines with overbudget checks

### DIFF
--- a/src/services/budgetLines.ts
+++ b/src/services/budgetLines.ts
@@ -1,4 +1,4 @@
-import { collection, getDocs, addDoc, updateDoc, deleteDoc, doc, query, where } from 'firebase/firestore';
+import { collection, getDocs, addDoc, updateDoc, deleteDoc, doc, query, where, getDoc } from 'firebase/firestore';
 import { db } from './firebase';
 
 const COLLECTION_NAME = 'budget-lines';
@@ -25,6 +25,17 @@ export const getBudgetLines = async (): Promise<BudgetLine[]> => {
     createdAt: d.data().createdAt?.toDate ? d.data().createdAt.toDate() : undefined,
     updatedAt: d.data().updatedAt?.toDate ? d.data().updatedAt.toDate() : undefined,
   })) as BudgetLine[];
+};
+
+export const getBudgetLineById = async (id: string): Promise<BudgetLine | null> => {
+  const d = await getDoc(doc(db, COLLECTION_NAME, id));
+  if (!d.exists()) return null;
+  return {
+    id: d.id,
+    ...d.data(),
+    createdAt: d.data().createdAt?.toDate ? d.data().createdAt.toDate() : undefined,
+    updatedAt: d.data().updatedAt?.toDate ? d.data().updatedAt.toDate() : undefined,
+  } as BudgetLine;
 };
 
 export const findBudgetLine = async (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -144,6 +144,9 @@ export interface PaymentRequest {
   scope?: string;
   justification?: string;
   inBudget?: boolean;
+  budgetLineId?: string;
+  isOverBudget?: boolean;
+  overBudgetReason?: string;
 
   // Dados fiscais
   fiscalStatus?: 'pending' | 'approved' | 'pending_adjustment';


### PR DESCRIPTION
## Summary
- add dropdown to select budget line when expense is marked within budget
- compute monthly budget usage and request justification when over limit
- expose helpers to fetch budget lines and sum expenses per line

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a763da1320832d8ab8864607753b1a