### PR TITLE
Restrict basic user actions on requests

### DIFF
--- a/src/pages/RequestsPage.jsx
+++ b/src/pages/RequestsPage.jsx
@@ -463,7 +463,7 @@ export const RequestsPage = () => {
                           >
                             <Eye className="w-4 h-4" />
                           </button>
-                          {request.status === 'pending_owner_approval' && (
+                          {!isBasicUser && request.status === 'pending_owner_approval' && (
                             <>
                               <button
                                 onClick={() => handleApprove(request.id)}
@@ -483,13 +483,15 @@ export const RequestsPage = () => {
                               </button>
                             </>
                           )}
-                          <button
-                            onClick={() => navigate(`/requests/${request.id}/edit`)}
-                            className="text-gray-600 hover:text-gray-900"
-                            title="Editar"
-                          >
-                            <Edit className="w-4 h-4" />
-                          </button>
+                          {(!isBasicUser || request.status === 'pending_owner_approval') && (
+                            <button
+                              onClick={() => navigate(`/requests/${request.id}/edit`)}
+                              className="text-gray-600 hover:text-gray-900"
+                              title="Editar"
+                            >
+                              <Edit className="w-4 h-4" />
+                            </button>
+                          )}
                         </div>
                       </td>
                     </tr>


### PR DESCRIPTION
## Summary
- hide approve/reject options for basic users on requests page
- limit edit button to requests waiting for owner approval

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a76489163c832d8a8768d386a07071