### PR TITLE
feat: enhance owner approvals workflow

### DIFF
--- a/src/components/RequestDetailsModal.jsx
+++ b/src/components/RequestDetailsModal.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog';
+import { formatCurrency, formatDate } from '@/utils';
+import { useRequest } from '@/hooks/useRequests';
+
+const RequestDetailsModal = ({ requestId, open, onClose }) => {
+  const { data: request, isLoading } = useRequest(requestId);
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Detalhes da Despesa</DialogTitle>
+        </DialogHeader>
+        {isLoading ? (
+          <div className="py-4">Carregando...</div>
+        ) : request ? (
+          <div className="space-y-2 text-sm">
+            <div>
+              <span className="font-medium">Solicitação:</span> {request.requestNumber || request.number}
+            </div>
+            <div>
+              <span className="font-medium">Nome da Despesa:</span> {request.title}
+            </div>
+            <div>
+              <span className="font-medium">Fornecedor:</span> {request.vendorName}
+            </div>
+            <div>
+              <span className="font-medium">Valor:</span> {formatCurrency(request.amount)}
+            </div>
+            <div>
+              <span className="font-medium">Competência:</span> {request.competenceDate ? formatDate(request.competenceDate) : '-'}
+            </div>
+            <div>
+              <span className="font-medium">Vencimento:</span> {formatDate(request.dueDate)}
+            </div>
+            {request.description && (
+              <div>
+                <span className="font-medium">Descrição:</span> {request.description}
+              </div>
+            )}
+          </div>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default RequestDetailsModal;


### PR DESCRIPTION
## Summary
- add modal with full expense details
- allow selecting multiple pending expenses and mass approval
- show value, expense name, supplier, competence and due date in history table

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7672bb204832d8160bbee5dbb9f5d