### PR TITLE
Replace browser confirm dialogs with custom modal

### DIFF
--- a/src/hooks/useConfirm.jsx
+++ b/src/hooks/useConfirm.jsx
@@ -1,0 +1,54 @@
+import { useState, useRef, useCallback } from 'react';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog';
+
+export const useConfirm = () => {
+  const [open, setOpen] = useState(false);
+  const resolveRef = useRef(null);
+  const messageRef = useRef('');
+
+  const confirm = useCallback((message) => {
+    messageRef.current = message;
+    setOpen(true);
+    return new Promise((resolve) => {
+      resolveRef.current = resolve;
+    });
+  }, []);
+
+  const handleCancel = () => {
+    setOpen(false);
+    resolveRef.current?.(false);
+  };
+
+  const handleConfirm = () => {
+    setOpen(false);
+    resolveRef.current?.(true);
+  };
+
+  const ConfirmationDialog = () => (
+    <AlertDialog open={open} onOpenChange={(o) => !o && handleCancel()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Confirmação</AlertDialogTitle>
+          <AlertDialogDescription>{messageRef.current}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={handleCancel}>Cancelar</AlertDialogCancel>
+          <AlertDialogAction onClick={handleConfirm}>Confirmar</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+
+  return { confirm, ConfirmationDialog };
+};
+
+export default useConfirm;

--- a/src/pages/ContractReviewPage.jsx
+++ b/src/pages/ContractReviewPage.jsx
@@ -3,6 +3,7 @@ import { useVendors, useApproveVendorContract, useRequestVendorContractAdjustmen
 import { useRequestsList, useApproveRequestContract, useRequestContractAdjustments } from '@/hooks/useRequests';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { formatCNPJ } from '@/utils';
+import { useConfirm } from '@/hooks/useConfirm';
 
 export const ContractReviewPage = () => {
   const { data: vendorsData, isLoading, isError } = useVendors({ status: 'contract_review', page: 1, limit: 50 });
@@ -13,8 +14,10 @@ export const ContractReviewPage = () => {
   const approveRequestContract = useApproveRequestContract();
   const requestRequestAdjustments = useRequestContractAdjustments();
 
+  const { confirm, ConfirmationDialog } = useConfirm();
+
   const handleApprove = async (id) => {
-    if (window.confirm('Aprovar contrato deste fornecedor?')) {
+    if (await confirm('Aprovar contrato deste fornecedor?')) {
       await approveContract.mutateAsync(id);
     }
   };
@@ -27,7 +30,7 @@ export const ContractReviewPage = () => {
   };
 
   const handleApproveRequest = async (id) => {
-    if (window.confirm('Aprovar contrato desta solicitação?')) {
+    if (await confirm('Aprovar contrato desta solicitação?')) {
       await approveRequestContract.mutateAsync(id);
     }
   };
@@ -43,6 +46,7 @@ export const ContractReviewPage = () => {
   const requests = requestsData?.data ?? [];
 
   return (
+    <>
     <div className="space-y-6">
       <h1 className="text-3xl font-bold tracking-tight">Revisão de Contratos</h1>
       <div className="bg-white rounded-lg border overflow-hidden">
@@ -152,6 +156,8 @@ export const ContractReviewPage = () => {
         )}
       </div>
     </div>
+    <ConfirmationDialog />
+    </>
   );
 };
 

--- a/src/pages/VendorApprovalsPage.jsx
+++ b/src/pages/VendorApprovalsPage.jsx
@@ -9,6 +9,7 @@ import {
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { formatCNPJ, formatDate } from '@/utils';
 import VendorDetailsModal from '@/components/VendorDetailsModal';
+import { useConfirm } from '@/hooks/useConfirm';
 
 export const VendorApprovalsPage = () => {
   const { data: vendorsData, isLoading, isError } = useVendors({
@@ -37,8 +38,10 @@ export const VendorApprovalsPage = () => {
   const rejectVendor = useRejectVendor();
   const requestInfoVendor = useRequestMoreInfoVendor();
 
+  const { confirm, ConfirmationDialog } = useConfirm();
+
   const handleApprove = async (id) => {
-    if (window.confirm('Aprovar este fornecedor?')) {
+    if (await confirm('Aprovar este fornecedor?')) {
       await approveVendor.mutateAsync(id);
     }
   };
@@ -84,6 +87,7 @@ export const VendorApprovalsPage = () => {
   };
 
   return (
+    <>
     <div className="space-y-6">
       <h1 className="text-3xl font-bold tracking-tight">Aprovação de Fornecedores</h1>
       <div className="bg-white rounded-lg border overflow-hidden">
@@ -247,5 +251,7 @@ export const VendorApprovalsPage = () => {
         requestInfoDisabled={requestInfoVendor.isPending}
       />
     </div>
+    <ConfirmationDialog />
+    </>
   );
 };

--- a/src/pages/VendorsPage.jsx
+++ b/src/pages/VendorsPage.jsx
@@ -13,6 +13,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
 import { useForm } from 'react-hook-form';
 import { useAuth } from '@/contexts/AuthContext';
+import { useConfirm } from '@/hooks/useConfirm';
 
 export const VendorsPage = () => {
   const { hasAnyRole, user } = useAuth();
@@ -29,32 +30,34 @@ export const VendorsPage = () => {
   const sendToLegal = useSendVendorToContractReview();
   const [isNewVendorOpen, setIsNewVendorOpen] = useState(false);
 
+  const { confirm, ConfirmationDialog } = useConfirm();
+
   const handleDeactivate = async (id) => {
-    if (window.confirm('Tem certeza que deseja desativar este fornecedor?')) {
+    if (await confirm('Tem certeza que deseja desativar este fornecedor?')) {
       await deactivateVendor.mutateAsync(id);
     }
   };
 
   const handleReactivate = async (id) => {
-    if (window.confirm('Tem certeza que deseja reativar este fornecedor?')) {
+    if (await confirm('Tem certeza que deseja reativar este fornecedor?')) {
       await reactivateVendor.mutateAsync(id);
     }
   };
 
   const handleBlock = async (id) => {
-    if (window.confirm('Tem certeza que deseja bloquear este fornecedor?')) {
+    if (await confirm('Tem certeza que deseja bloquear este fornecedor?')) {
       await blockVendor.mutateAsync(id);
     }
   };
 
   const handleUnblock = async (id) => {
-    if (window.confirm('Tem certeza que deseja desbloquear este fornecedor?')) {
+    if (await confirm('Tem certeza que deseja desbloquear este fornecedor?')) {
       await unblockVendor.mutateAsync(id);
     }
   };
 
   const handleSendToLegal = async (id) => {
-    if (window.confirm('Enviar contrato para revisão jurídica?')) {
+    if (await confirm('Enviar contrato para revisão jurídica?')) {
       await sendToLegal.mutateAsync({ id, requesterId: user.id });
     }
   };
@@ -275,6 +278,7 @@ export const VendorsPage = () => {
         </div>
       )}
       </div>
+      <ConfirmationDialog />
     </>
   );
 };


### PR DESCRIPTION
## Summary
- add reusable `useConfirm` hook built on Radix AlertDialog
- replace `window.confirm` prompts with custom confirmation modal across vendor-related pages

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a76851f4e8832d88dde72ed1f8dde1