### PR TITLE
Add contextual help tooltips to forms

### DIFF
--- a/src/components/BudgetRequestModal.jsx
+++ b/src/components/BudgetRequestModal.jsx
@@ -49,34 +49,34 @@ const BudgetRequestModal = ({ open, onClose }) => {
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium">Título</label>
+            <label className="block text-sm font-medium" data-tooltip="Título do pedido de orçamento">Título</label>
             <Input value={title} onChange={(e) => setTitle(e.target.value)} required />
           </div>
           <div>
-            <label className="block text-sm font-medium">Descrição</label>
+            <label className="block text-sm font-medium" data-tooltip="Detalhe o que deseja adquirir">Descrição</label>
             <Textarea value={description} onChange={(e) => setDescription(e.target.value)} required />
           </div>
           <div className="flex items-center space-x-2">
             <Checkbox checked={inBudget} onCheckedChange={(v) => setInBudget(!!v)} id="inBudget" />
-            <label htmlFor="inBudget" className="text-sm">Está em orçamento?</label>
+            <label htmlFor="inBudget" className="text-sm" data-tooltip="Indica se o gasto está previsto">Está em orçamento?</label>
           </div>
           {inBudget ? (
             <div>
-              <label className="block text-sm font-medium">Linha de orçamento</label>
+              <label className="block text-sm font-medium" data-tooltip="Informe a linha do orçamento existente">Linha de orçamento</label>
               <Input value={budgetLine} onChange={(e) => setBudgetLine(e.target.value)} />
             </div>
           ) : (
             <div>
-              <label className="block text-sm font-medium">Explicação</label>
+              <label className="block text-sm font-medium" data-tooltip="Justifique por que não está no orçamento">Explicação</label>
               <Textarea value={explanation} onChange={(e) => setExplanation(e.target.value)} />
             </div>
           )}
           <div>
-            <label className="block text-sm font-medium">Anexos</label>
+            <label className="block text-sm font-medium" data-tooltip="Anexe documentos relevantes">Anexos</label>
             <Input type="file" multiple onChange={(e) => setAttachments(Array.from(e.target.files || []))} />
           </div>
           <div>
-            <label className="block text-sm font-medium">Sugestão de fornecedores</label>
+            <label className="block text-sm font-medium" data-tooltip="Liste possíveis fornecedores">Sugestão de fornecedores</label>
             <Textarea value={supplierSuggestions} onChange={(e) => setSupplierSuggestions(e.target.value)} />
           </div>
           <DialogFooter>

--- a/src/components/NewRequestModal.jsx
+++ b/src/components/NewRequestModal.jsx
@@ -235,27 +235,27 @@ export const NewRequestModal = ({ open, onClose }) => {
         </DialogHeader>
         <form onSubmit={handleSubmit} className="grid gap-4 sm:grid-cols-2">
           <div className="sm:col-span-2">
-            <label className="block text-sm font-medium mb-1">Nome da despesa</label>
+            <label className="block text-sm font-medium mb-1" data-tooltip="Identificação da despesa">Nome da despesa</label>
             <Input value={expenseName} onChange={(e) => setExpenseName(e.target.value)} required />
           </div>
           <div className="flex items-center space-x-2 sm:col-span-2">
             <Checkbox id="extra" checked={isExtraordinary} onCheckedChange={(v) => setIsExtraordinary(!!v)} />
-            <label htmlFor="extra" className="text-sm">Solicitação extraordinária</label>
+            <label htmlFor="extra" className="text-sm" data-tooltip="Marque se o fornecedor não está cadastrado">Solicitação extraordinária</label>
           </div>
           {isExtraordinary ? (
             <>
               <div className="sm:col-span-2">
-                <label className="block text-sm font-medium mb-1">Fornecedor</label>
+                <label className="block text-sm font-medium mb-1" data-tooltip="Informe o nome do fornecedor">Fornecedor</label>
                 <Input value={vendorName} onChange={(e) => setVendorName(e.target.value)} required />
               </div>
               <div className="sm:col-span-2">
-                <label className="block text-sm font-medium mb-1">Motivo da solicitação</label>
+                <label className="block text-sm font-medium mb-1" data-tooltip="Justifique a necessidade da solicitação extraordinária">Motivo da solicitação</label>
                 <Textarea value={reason} onChange={(e) => setReason(e.target.value)} required />
               </div>
             </>
           ) : (
             <div className="sm:col-span-2">
-              <label className="block text-sm font-medium mb-1">Fornecedor</label>
+              <label className="block text-sm font-medium mb-1" data-tooltip="Escolha um fornecedor existente">Fornecedor</label>
               <Select value={vendorId} onValueChange={setVendorId}>
                 <SelectTrigger className="w-full">
                   <SelectValue placeholder="Selecione" />
@@ -274,15 +274,15 @@ export const NewRequestModal = ({ open, onClose }) => {
             </div>
           )}
           <div>
-            <label className="block text-sm font-medium mb-1">Número da NF</label>
+            <label className="block text-sm font-medium mb-1" data-tooltip="Número da nota fiscal relacionada">Número da NF</label>
             <Input value={invoiceNumber} onChange={(e) => setInvoiceNumber(e.target.value)} />
           </div>
           <div>
-            <label className="block text-sm font-medium mb-1">Valor bruto</label>
+            <label className="block text-sm font-medium mb-1" data-tooltip="Valor total da nota sem descontos">Valor bruto</label>
             <Input type="number" step="0.01" value={amount} onChange={(e) => setAmount(e.target.value)} required />
           </div>
           <div>
-            <label className="block text-sm font-medium mb-1">Tipo de custo</label>
+            <label className="block text-sm font-medium mb-1" data-tooltip="Classificação contábil do gasto">Tipo de custo</label>
             <Select value={costType} onValueChange={setCostType}>
               <SelectTrigger className="w-full">
                 <SelectValue />
@@ -295,7 +295,7 @@ export const NewRequestModal = ({ open, onClose }) => {
             </Select>
           </div>
           <div>
-            <label className="block text-sm font-medium mb-1">Tipo de compra</label>
+            <label className="block text-sm font-medium mb-1" data-tooltip="Categoria da compra realizada">Tipo de compra</label>
             <Select value={purchaseType} onValueChange={setPurchaseType}>
               <SelectTrigger className="w-full">
                 <SelectValue placeholder="Selecione" />
@@ -309,19 +309,19 @@ export const NewRequestModal = ({ open, onClose }) => {
             </Select>
           </div>
           <div>
-            <label className="block text-sm font-medium mb-1">Tipo de serviço</label>
+            <label className="block text-sm font-medium mb-1" data-tooltip="Tipo de serviço prestado">Tipo de serviço</label>
             <Input value={serviceType} onChange={(e) => setServiceType(e.target.value)} readOnly={!isExtraordinary} />
           </div>
           <div className="sm:col-span-2">
-            <label className="block text-sm font-medium mb-1">Escopo</label>
+            <label className="block text-sm font-medium mb-1" data-tooltip="Descrição resumida do escopo do serviço">Escopo</label>
             <Textarea value={scope} onChange={(e) => setScope(e.target.value)} readOnly={!isExtraordinary} />
           </div>
           <div className="sm:col-span-2">
-            <label className="block text-sm font-medium mb-1">Justificativa</label>
+            <label className="block text-sm font-medium mb-1" data-tooltip="Detalhe o motivo da solicitação">Justificativa</label>
             <Textarea value={justification} onChange={(e) => setJustification(e.target.value)} />
           </div>
           <div>
-            <label className="block text-sm font-medium mb-1">Centro de custo</label>
+            <label className="block text-sm font-medium mb-1" data-tooltip="Centro de custo responsável">Centro de custo</label>
             <Select value={costCenterId} onValueChange={setCostCenterId}>
               <SelectTrigger className="w-full">
                 <SelectValue placeholder="Selecione" />
@@ -335,11 +335,11 @@ export const NewRequestModal = ({ open, onClose }) => {
           </div>
           <div className="flex items-center space-x-2 sm:col-span-2">
             <Checkbox id="inBudget" checked={inBudget} onCheckedChange={(v) => setInBudget(!!v)} />
-            <label htmlFor="inBudget" className="text-sm">Dentro do orçamento</label>
+            <label htmlFor="inBudget" className="text-sm" data-tooltip="Indica se a despesa já está prevista no orçamento">Dentro do orçamento</label>
           </div>
           {inBudget && (
             <div className="sm:col-span-2">
-              <label className="block text-sm font-medium mb-1">Linha do orçamento</label>
+              <label className="block text-sm font-medium mb-1" data-tooltip="Selecione a linha do orçamento correspondente">Linha do orçamento</label>
               <Select value={budgetLineId} onValueChange={setBudgetLineId}>
                 <SelectTrigger className="w-full">
                   <SelectValue placeholder="Selecione" />
@@ -359,36 +359,36 @@ export const NewRequestModal = ({ open, onClose }) => {
           )}
           {inBudget && isOverBudget && (
             <div className="sm:col-span-2">
-              <label className="block text-sm font-medium mb-1">Justificativa do estouro</label>
+              <label className="block text-sm font-medium mb-1" data-tooltip="Explique por que ultrapassa o orçamento">Justificativa do estouro</label>
               <Textarea value={overBudgetReason} onChange={(e) => setOverBudgetReason(e.target.value)} required />
             </div>
           )}
           <div className="flex items-center space-x-2 sm:col-span-2">
             <Checkbox id="recurring" checked={isRecurring} onCheckedChange={(v) => setIsRecurring(!!v)} />
-            <label htmlFor="recurring" className="text-sm">Lançamento recorrente</label>
+            <label htmlFor="recurring" className="text-sm" data-tooltip="Marque se esta despesa se repetirá periodicamente">Lançamento recorrente</label>
           </div>
           <div>
-            <label className="block text-sm font-medium mb-1">Data de emissão</label>
+            <label className="block text-sm font-medium mb-1" data-tooltip="Data de emissão da nota fiscal">Data de emissão</label>
             <Input type="date" value={invoiceDate} onChange={(e) => setInvoiceDate(e.target.value)} required />
           </div>
           <div>
-            <label className="block text-sm font-medium mb-1">Competência</label>
+            <label className="block text-sm font-medium mb-1" data-tooltip="Mês/ano de competência da despesa">Competência</label>
             <Input type="month" value={competenceDate} onChange={(e) => setCompetenceDate(e.target.value)} required />
           </div>
           <div>
-            <label className="block text-sm font-medium mb-1">Data de vencimento</label>
+            <label className="block text-sm font-medium mb-1" data-tooltip="Data prevista para pagamento">Data de vencimento</label>
             <Input type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} readOnly={!isExtraordinary} required />
           </div>
           <div className="sm:col-span-2">
-            <label className="block text-sm font-medium mb-1">Boleto</label>
+            <label className="block text-sm font-medium mb-1" data-tooltip="Anexe o boleto para pagamento">Boleto</label>
             <Input type="file" onChange={(e) => setBoletoFile(e.target.files?.[0] || null)} />
           </div>
           <div className="sm:col-span-2">
-            <label className="block text-sm font-medium mb-1">NF</label>
+            <label className="block text-sm font-medium mb-1" data-tooltip="Anexe a nota fiscal">NF</label>
             <Input type="file" onChange={(e) => setNfFile(e.target.files?.[0] || null)} />
           </div>
           <div className="sm:col-span-2">
-            <label className="block text-sm font-medium mb-1">Orçamentos</label>
+            <label className="block text-sm font-medium mb-1" data-tooltip="Envie arquivos de orçamentos obtidos">Orçamentos</label>
             <Input type="file" multiple onChange={(e) => setQuotationFiles(Array.from(e.target.files || []))} />
           </div>
           <DialogFooter className="sm:col-span-2">

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,44 @@
+label[data-tooltip] {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: help;
+}
+
+label[data-tooltip]::after {
+  content: "?";
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.25rem;
+  width: 1rem;
+  height: 1rem;
+  font-size: 0.75rem;
+  border-radius: 9999px;
+  background-color: #e5e7eb;
+  color: #374151;
+}
+
+label[data-tooltip]::before {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  transform: translateY(-0.25rem);
+  padding: 0.25rem 0.5rem;
+  background-color: #111827;
+  color: #f9fafb;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  white-space: pre-wrap;
+  max-width: 16rem;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease;
+  z-index: 10;
+}
+
+label[data-tooltip]:hover::before {
+  opacity: 1;
+  visibility: visible;
+}

--- a/src/pages/BudgetsPage.jsx
+++ b/src/pages/BudgetsPage.jsx
@@ -159,7 +159,7 @@ export const BudgetsPage = () => {
           <form onSubmit={handleSubmit} className="space-y-4">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700">Fornecedor</label>
+                <label className="block text-sm font-medium text-gray-700" data-tooltip="Fornecedor relacionado à linha">Fornecedor</label>
                 <select
                   name="vendorId"
                   value={form.vendorId}
@@ -176,7 +176,7 @@ export const BudgetsPage = () => {
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700">Descrição</label>
+                <label className="block text-sm font-medium text-gray-700" data-tooltip="Descrição da linha orçamentária">Descrição</label>
                 <input
                   name="description"
                   value={form.description}
@@ -187,7 +187,7 @@ export const BudgetsPage = () => {
               </div>
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700">Centro de Custo</label>
+              <label className="block text-sm font-medium text-gray-700" data-tooltip="Centro de custo responsável">Centro de Custo</label>
               <select
                 name="costCenterId"
                 value={form.costCenterId}
@@ -205,7 +205,7 @@ export const BudgetsPage = () => {
             </div>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700">Natureza</label>
+                <label className="block text-sm font-medium text-gray-700" data-tooltip="Indica se o custo é fixo ou variável">Natureza</label>
                 <select
                   name="nature"
                   value={form.nature}
@@ -217,7 +217,7 @@ export const BudgetsPage = () => {
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700">Tipo de Custo</label>
+                <label className="block text-sm font-medium text-gray-700" data-tooltip="Classificação contábil (CAPEX/OPEX/CPO)">Tipo de Custo</label>
                 <select
                   name="costType"
                   value={form.costType}
@@ -230,7 +230,7 @@ export const BudgetsPage = () => {
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700">Ano</label>
+                <label className="block text-sm font-medium text-gray-700" data-tooltip="Ano de referência do orçamento">Ano</label>
                 <input
                   type="number"
                   name="year"
@@ -243,7 +243,7 @@ export const BudgetsPage = () => {
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-4">
               {Object.keys(form.months).map((month) => (
                 <div key={month}>
-                  <label className="block text-sm font-medium text-gray-700">
+                  <label className="block text-sm font-medium text-gray-700" data-tooltip="Valor previsto para o mês">
                     {new Date(0, month - 1).toLocaleString('pt-BR', { month: 'short' })}
                   </label>
                   <input

--- a/src/pages/CostCentersPage.jsx
+++ b/src/pages/CostCentersPage.jsx
@@ -114,7 +114,7 @@ export const CostCentersPage = () => {
             <h2 className="text-lg font-semibold mb-4">Novo Centro de Custo</h2>
             <form onSubmit={handleSubmit} className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700">Nome</label>
+                <label className="block text-sm font-medium text-gray-700" data-tooltip="Nome do centro de custo">Nome</label>
                 <input
                   name="name"
                   value={form.name}
@@ -124,7 +124,7 @@ export const CostCentersPage = () => {
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700">Gerente</label>
+                <label className="block text-sm font-medium text-gray-700" data-tooltip="Responsável principal pelo centro">Gerente</label>
                 <select
                   name="managerId"
                   value={form.managerId}
@@ -141,7 +141,7 @@ export const CostCentersPage = () => {
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700">Diretor</label>
+                <label className="block text-sm font-medium text-gray-700" data-tooltip="Diretor associado ao centro">Diretor</label>
                 <select
                   name="directorId"
                   value={form.directorId}

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -36,7 +36,7 @@ export const LoginPage = () => {
         {error && <p className="text-sm text-red-500">{error}</p>}
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="email">Email</Label>
+            <Label htmlFor="email" data-tooltip="Informe seu e-mail corporativo">Email</Label>
             <Input
               id="email"
               type="email"
@@ -46,7 +46,7 @@ export const LoginPage = () => {
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="password">Senha</Label>
+            <Label htmlFor="password" data-tooltip="Digite sua senha de acesso">Senha</Label>
             <Input
               id="password"
               type="password"

--- a/src/pages/UsersPage.jsx
+++ b/src/pages/UsersPage.jsx
@@ -63,7 +63,7 @@ export const UsersPage = () => {
         <h2 className="text-xl font-semibold mb-4">Cadastrar Novo Usuário</h2>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700">Nome</label>
+            <label className="block text-sm font-medium text-gray-700" data-tooltip="Nome completo do usuário">Nome</label>
             <input
               name="name"
               value={form.name}
@@ -73,7 +73,7 @@ export const UsersPage = () => {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700">E-mail</label>
+            <label className="block text-sm font-medium text-gray-700" data-tooltip="E-mail corporativo">E-mail</label>
             <input
               name="email"
               type="email"
@@ -84,7 +84,7 @@ export const UsersPage = () => {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700">Role</label>
+            <label className="block text-sm font-medium text-gray-700" data-tooltip="Perfil de acesso inicial">Role</label>
             <select
               name="role"
               value={form.role}

--- a/src/pages/VendorsPage.jsx
+++ b/src/pages/VendorsPage.jsx
@@ -373,7 +373,7 @@ const NewVendorDialog = ({ open, onOpenChange }) => {
               rules={{ required: 'Nome é obrigatório' }}
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Nome</FormLabel>
+                  <FormLabel data-tooltip="Nome do fornecedor">Nome</FormLabel>
                   <FormControl>
                     <Input {...field} />
                   </FormControl>
@@ -387,7 +387,7 @@ const NewVendorDialog = ({ open, onOpenChange }) => {
               rules={{ required: 'CNPJ é obrigatório' }}
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>CNPJ</FormLabel>
+                  <FormLabel data-tooltip="CNPJ com 14 dígitos">CNPJ</FormLabel>
                   <FormControl>
                     <Input
                       {...field}
@@ -404,7 +404,7 @@ const NewVendorDialog = ({ open, onOpenChange }) => {
               name="email"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>E-mail</FormLabel>
+                  <FormLabel data-tooltip="E-mail de contato">E-mail</FormLabel>
                   <FormControl>
                     <Input type="email" {...field} />
                   </FormControl>
@@ -417,7 +417,7 @@ const NewVendorDialog = ({ open, onOpenChange }) => {
               name="phone"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Telefone</FormLabel>
+                  <FormLabel data-tooltip="Telefone com DDD">Telefone</FormLabel>
                   <FormControl>
                     <Input
                       {...field}
@@ -433,7 +433,7 @@ const NewVendorDialog = ({ open, onOpenChange }) => {
               name="rating"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Rating</FormLabel>
+                  <FormLabel data-tooltip="Avaliação de 1 a 5 estrelas">Rating</FormLabel>
                   <FormControl>
                     <div className="flex space-x-1">
                       {[1, 2, 3, 4, 5].map((i) => (
@@ -457,7 +457,7 @@ const NewVendorDialog = ({ open, onOpenChange }) => {
               )}
             />
             <div>
-              <FormLabel>Tags</FormLabel>
+              <FormLabel data-tooltip="Palavras-chave para categorizar">Tags</FormLabel>
               <div className="flex flex-wrap gap-1 mb-2">
                 {tags.map((tag) => (
                   <Badge key={tag} variant="secondary">
@@ -498,7 +498,7 @@ const NewVendorDialog = ({ open, onOpenChange }) => {
             name="paymentTerms"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Prazo de Pagamento</FormLabel>
+                <FormLabel data-tooltip="Condição de pagamento (ex.: 30 dias)">Prazo de Pagamento</FormLabel>
                 <FormControl>
                   <Input {...field} />
                 </FormControl>
@@ -510,7 +510,7 @@ const NewVendorDialog = ({ open, onOpenChange }) => {
             name="serviceType"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Tipo de Serviço</FormLabel>
+                <FormLabel data-tooltip="Serviço principal prestado">Tipo de Serviço</FormLabel>
                 <FormControl>
                   <Input {...field} />
                 </FormControl>
@@ -522,7 +522,7 @@ const NewVendorDialog = ({ open, onOpenChange }) => {
             name="scope"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Escopo</FormLabel>
+                <FormLabel data-tooltip="Descrição do escopo acordado">Escopo</FormLabel>
                 <FormControl>
                   <Textarea {...field} />
                 </FormControl>
@@ -540,13 +540,13 @@ const NewVendorDialog = ({ open, onOpenChange }) => {
                     onCheckedChange={field.onChange}
                   />
                 </FormControl>
-                <FormLabel className="mb-0">Possui contrato?</FormLabel>
+                <FormLabel className="mb-0" data-tooltip="Marque se existe contrato vigente">Possui contrato?</FormLabel>
               </FormItem>
             )}
           />
           {form.watch('hasContract') && (
             <div>
-              <FormLabel>Arquivo do Contrato</FormLabel>
+              <FormLabel data-tooltip="Anexe o arquivo do contrato">Arquivo do Contrato</FormLabel>
               <Input
                 type="file"
                 onChange={(e) => setContractFile(e.target.files?.[0] || null)}
@@ -558,7 +558,7 @@ const NewVendorDialog = ({ open, onOpenChange }) => {
             name="observations"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Observações</FormLabel>
+                <FormLabel data-tooltip="Informações adicionais">Observações</FormLabel>
                 <FormControl>
                   <Textarea {...field} />
                 </FormControl>


### PR DESCRIPTION
## Summary
- show `?` icon with explanatory tooltip on hover for labeled fields
- document form fields across app with descriptive tooltips

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7689f7070832da02d207eb8c38025