### PR TITLE
Remove budget column from cost centers page

### DIFF
--- a/src/pages/CostCentersPage.jsx
+++ b/src/pages/CostCentersPage.jsx
@@ -57,7 +57,7 @@ export const CostCentersPage = () => {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Centros de Custo</h1>
-          <p className="text-muted-foreground">Gerencie centros de custo e orçamentos</p>
+          <p className="text-muted-foreground">Gerencie centros de custo</p>
         </div>
         <button
           onClick={() => setShowModal(true)}
@@ -77,7 +77,6 @@ export const CostCentersPage = () => {
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Código</th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nome</th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Gerente</th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Orçamento</th>
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
@@ -86,19 +85,11 @@ export const CostCentersPage = () => {
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 font-mono">{cc.code}</td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{cc.name}</td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{getManagerEmail(cc.managerId)}</td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                    {cc.budget != null
-                      ? cc.budget.toLocaleString('pt-BR', {
-                          style: 'currency',
-                          currency: 'BRL'
-                        })
-                      : '—'}
-                  </td>
                 </tr>
               ))}
               {costCenters.length === 0 && (
                 <tr>
-                  <td colSpan={4} className="px-6 py-4 text-center text-sm text-gray-500">
+                  <td colSpan={3} className="px-6 py-4 text-center text-sm text-gray-500">
                     Nenhum centro de custo cadastrado
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- remove budget column from cost centers table
- update empty-state colSpan and description

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a77047cc54832da54528b0a723dc16