### PR TITLE
feat: replace prompts with confirmation modals

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import { HashRouter } from 'react-router-dom';
 import { queryClient } from './lib/react-query';
 import { AppRoutes } from './routes';
 import { AuthProvider } from './contexts/AuthContext';
+import { PromptProvider } from './contexts/PromptContext';
 import './App.css';
 
 function App() {
@@ -11,10 +12,12 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <HashRouter>
         <AuthProvider>
-          <div className="min-h-screen bg-background">
-            <AppRoutes />
-          </div>
-          <ReactQueryDevtools initialIsOpen={false} />
+          <PromptProvider>
+            <div className="min-h-screen bg-background">
+              <AppRoutes />
+            </div>
+            <ReactQueryDevtools initialIsOpen={false} />
+          </PromptProvider>
         </AuthProvider>
       </HashRouter>
     </QueryClientProvider>

--- a/src/contexts/PromptContext.jsx
+++ b/src/contexts/PromptContext.jsx
@@ -1,0 +1,59 @@
+import { createContext, useContext, useState } from 'react';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog';
+import { Input } from '@/components/ui/input';
+
+const PromptContext = createContext(null);
+
+export const PromptProvider = ({ children }) => {
+  const [state, setState] = useState({ open: false, title: '', resolve: () => {} });
+  const [value, setValue] = useState('');
+
+  const prompt = ({ title }) =>
+    new Promise((resolve) => {
+      setState({ open: true, title, resolve });
+      setValue('');
+    });
+
+  const handleCancel = () => {
+    state.resolve(null);
+    setState((s) => ({ ...s, open: false, resolve: () => {} }));
+  };
+
+  const handleConfirm = () => {
+    state.resolve(value);
+    setState((s) => ({ ...s, open: false, resolve: () => {} }));
+  };
+
+  return (
+    <PromptContext.Provider value={prompt}>
+      {children}
+      <AlertDialog open={state.open}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{state.title}</AlertDialogTitle>
+          </AlertDialogHeader>
+          <Input value={value} onChange={(e) => setValue(e.target.value)} />
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={handleCancel}>Cancelar</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirm}>OK</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </PromptContext.Provider>
+  );
+};
+
+export const usePrompt = () => {
+  const ctx = useContext(PromptContext);
+  if (!ctx) throw new Error('usePrompt must be used within PromptProvider');
+  return ctx;
+};
+

--- a/src/pages/AccountingMonitorPage.jsx
+++ b/src/pages/AccountingMonitorPage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useAuth } from '../contexts/AuthContext';
+import { usePrompt } from '../contexts/PromptContext';
 import { useRequestsByStatus, useVerifyRequest, useReturnRequestWithError } from '../hooks/useRequests';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { formatCurrency } from '@/utils';
@@ -9,11 +10,12 @@ export const AccountingMonitorPage = () => {
   const { data, isLoading, isError } = useRequestsByStatus('pending_accounting_monitor');
   const verifyRequest = useVerifyRequest();
   const returnRequest = useReturnRequestWithError();
+  const prompt = usePrompt();
 
   const requests = data || [];
 
   const handleVerify = async (id) => {
-    const comments = window.prompt('Comentários da verificação');
+    const comments = await prompt({ title: 'Comentários da verificação' });
     await verifyRequest.mutateAsync({
       id,
       verifierId: user.id,
@@ -22,8 +24,8 @@ export const AccountingMonitorPage = () => {
     });
   };
 
-  const handleReturn = (id) => {
-    const reason = window.prompt('Motivo do retorno');
+  const handleReturn = async (id) => {
+    const reason = await prompt({ title: 'Motivo do retorno' });
     if (!reason) return;
     returnRequest.mutate({
       id,

--- a/src/pages/CeoApprovalsPage.jsx
+++ b/src/pages/CeoApprovalsPage.jsx
@@ -1,25 +1,27 @@
 import React from 'react';
 import { useRequestsList, useApproveRequest, useRejectRequest } from '../hooks/useRequests';
 import { useAuth } from '../contexts/AuthContext';
+import { usePrompt } from '../contexts/PromptContext';
 
 export const CeoApprovalsPage = () => {
   const { user } = useAuth();
   const { data, isLoading } = useRequestsList({ page: 1, limit: 50, status: 'pending_ceo_approval' });
   const approveRequest = useApproveRequest();
   const rejectRequest = useRejectRequest();
+  const prompt = usePrompt();
   const requests = data?.data || [];
 
   const formatCurrency = (value) =>
     new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
 
-  const handleApprove = (id) => {
-    const comments = window.prompt('Comentário da aprovação');
+  const handleApprove = async (id) => {
+    const comments = await prompt({ title: 'Comentário da aprovação' });
     if (comments === null) return;
     approveRequest.mutate({ id, approverId: user.id, approverName: user.name, comments });
   };
 
-  const handleReject = (id) => {
-    const reason = window.prompt('Motivo da reprovação');
+  const handleReject = async (id) => {
+    const reason = await prompt({ title: 'Motivo da reprovação' });
     if (!reason) return;
     rejectRequest.mutate({ id, approverId: user.id, approverName: user.name, reason });
   };

--- a/src/pages/CfoApprovalsPage.jsx
+++ b/src/pages/CfoApprovalsPage.jsx
@@ -1,25 +1,27 @@
 import React from 'react';
 import { useRequestsList, useApproveRequest, useRejectRequest } from '../hooks/useRequests';
 import { useAuth } from '../contexts/AuthContext';
+import { usePrompt } from '../contexts/PromptContext';
 
 export const CfoApprovalsPage = () => {
   const { user } = useAuth();
   const { data, isLoading } = useRequestsList({ page: 1, limit: 50, status: 'pending_cfo_approval' });
   const approveRequest = useApproveRequest();
   const rejectRequest = useRejectRequest();
+  const prompt = usePrompt();
   const requests = data?.data || [];
 
   const formatCurrency = (value) =>
     new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
 
-  const handleApprove = (id) => {
-    const comments = window.prompt('Comentário da aprovação');
+  const handleApprove = async (id) => {
+    const comments = await prompt({ title: 'Comentário da aprovação' });
     if (comments === null) return;
     approveRequest.mutate({ id, approverId: user.id, approverName: user.name, comments });
   };
 
-  const handleReject = (id) => {
-    const reason = window.prompt('Motivo da reprovação');
+  const handleReject = async (id) => {
+    const reason = await prompt({ title: 'Motivo da reprovação' });
     if (!reason) return;
     rejectRequest.mutate({ id, approverId: user.id, approverName: user.name, reason });
   };

--- a/src/pages/ContractReviewPage.jsx
+++ b/src/pages/ContractReviewPage.jsx
@@ -4,6 +4,7 @@ import { useRequestsList, useApproveRequestContract, useRequestContractAdjustmen
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { formatCNPJ } from '@/utils';
 import { useConfirm } from '@/hooks/useConfirm';
+import { usePrompt } from '@/contexts/PromptContext';
 
 export const ContractReviewPage = () => {
   const { data: vendorsData, isLoading, isError } = useVendors({ status: 'contract_review', page: 1, limit: 50 });
@@ -15,6 +16,7 @@ export const ContractReviewPage = () => {
   const requestRequestAdjustments = useRequestContractAdjustments();
 
   const { confirm, ConfirmationDialog } = useConfirm();
+  const prompt = usePrompt();
 
   const handleApprove = async (id) => {
     if (await confirm('Aprovar contrato deste fornecedor?')) {
@@ -23,7 +25,7 @@ export const ContractReviewPage = () => {
   };
 
   const handleRequestAdjustments = async (id) => {
-    const notes = window.prompt('Informe as notas do jurídico:');
+    const notes = await prompt({ title: 'Informe as notas do jurídico:' });
     if (notes) {
       await requestAdjustments.mutateAsync({ id, notes });
     }
@@ -36,7 +38,7 @@ export const ContractReviewPage = () => {
   };
 
   const handleRequestAdjustmentsRequest = async (id) => {
-    const notes = window.prompt('Informe as notas do jurídico:');
+    const notes = await prompt({ title: 'Informe as notas do jurídico:' });
     if (notes) {
       await requestRequestAdjustments.mutateAsync({ id, notes });
     }

--- a/src/pages/DirectorApprovalsPage.jsx
+++ b/src/pages/DirectorApprovalsPage.jsx
@@ -1,25 +1,27 @@
 import React from 'react';
 import { useRequestsList, useApproveRequest, useRejectRequest } from '../hooks/useRequests';
 import { useAuth } from '../contexts/AuthContext';
+import { usePrompt } from '../contexts/PromptContext';
 
 export const DirectorApprovalsPage = () => {
   const { user } = useAuth();
   const { data, isLoading } = useRequestsList({ page: 1, limit: 50, status: 'pending_director_approval' });
   const approveRequest = useApproveRequest();
   const rejectRequest = useRejectRequest();
+  const prompt = usePrompt();
   const requests = data?.data || [];
 
   const formatCurrency = (value) =>
     new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
 
-  const handleApprove = (id) => {
-    const comments = window.prompt('Comentário da aprovação');
+  const handleApprove = async (id) => {
+    const comments = await prompt({ title: 'Comentário da aprovação' });
     if (comments === null) return;
     approveRequest.mutate({ id, approverId: user.id, approverName: user.name, comments });
   };
 
-  const handleReject = (id) => {
-    const reason = window.prompt('Motivo da reprovação');
+  const handleReject = async (id) => {
+    const reason = await prompt({ title: 'Motivo da reprovação' });
     if (!reason) return;
     rejectRequest.mutate({ id, approverId: user.id, approverName: user.name, reason });
   };

--- a/src/pages/OwnerApprovalsPage.jsx
+++ b/src/pages/OwnerApprovalsPage.jsx
@@ -11,6 +11,7 @@ import { formatCurrency, formatDate } from '@/utils';
 import { DollarSign, Clock, CheckCircle } from 'lucide-react';
 import { Checkbox } from '@/components/ui/checkbox';
 import RequestDetailsModal from '@/components/RequestDetailsModal';
+import { usePrompt } from '../contexts/PromptContext';
 
 export const OwnerApprovalsPage = () => {
   const { user } = useAuth();
@@ -30,6 +31,7 @@ export const OwnerApprovalsPage = () => {
 
   const approveRequest = useApproveRequest();
   const rejectRequest = useRejectRequest();
+  const prompt = usePrompt();
 
   const userCostCenters = user?.ccScope ?? user?.costCenters ?? [];
   const pendingRequests = (pendingData ?? []).filter(
@@ -73,8 +75,8 @@ export const OwnerApprovalsPage = () => {
     }
   };
 
-  const handleApprove = (id) => {
-    const comments = window.prompt('Comentário da aprovação');
+  const handleApprove = async (id) => {
+    const comments = await prompt({ title: 'Comentário da aprovação' });
     if (comments === null) return;
     approveRequest.mutate({
       id,
@@ -84,8 +86,8 @@ export const OwnerApprovalsPage = () => {
     });
   };
 
-  const handleReject = (id) => {
-    const reason = window.prompt('Motivo da reprovação');
+  const handleReject = async (id) => {
+    const reason = await prompt({ title: 'Motivo da reprovação' });
     if (!reason) return;
     rejectRequest.mutate({
       id,
@@ -95,8 +97,8 @@ export const OwnerApprovalsPage = () => {
     });
   };
 
-  const handleApproveSelected = () => {
-    const comments = window.prompt('Comentário da aprovação');
+  const handleApproveSelected = async () => {
+    const comments = await prompt({ title: 'Comentário da aprovação' });
     if (comments === null) return;
     selectedIds.forEach((id) =>
       approveRequest.mutate({

--- a/src/pages/PaymentManagementPage.jsx
+++ b/src/pages/PaymentManagementPage.jsx
@@ -4,6 +4,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid } from 'recharts';
 import { ChartContainer, ChartTooltip, ChartTooltipContent, ChartLegend, ChartLegendContent } from '../components/ui/chart';
 import { usePaymentForecast } from '../hooks/useAnalytics';
+import { usePrompt } from '../contexts/PromptContext';
 
 export const PaymentManagementPage = () => {
   const { user } = useAuth();
@@ -13,6 +14,7 @@ export const PaymentManagementPage = () => {
   const { mutate: markAsPaid } = useMarkAsPaid();
   const { mutate: cancelRequest } = useCancelRequest();
   const requests = data?.data || [];
+  const prompt = usePrompt();
 
   const { data: forecastData = [] } = usePaymentForecast({
     startDate: startDate ? new Date(startDate) : undefined,
@@ -22,8 +24,8 @@ export const PaymentManagementPage = () => {
   const formatCurrency = (value) =>
     new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
 
-  const handlePaid = (id) => {
-    const notes = window.prompt('Observações do pagamento');
+  const handlePaid = async (id) => {
+    const notes = await prompt({ title: 'Observações do pagamento' });
     if (notes === null) return;
     markAsPaid({
       id,
@@ -36,8 +38,8 @@ export const PaymentManagementPage = () => {
     });
   };
 
-  const handleCancel = (id) => {
-    const reason = window.prompt('Motivo do cancelamento');
+  const handleCancel = async (id) => {
+    const reason = await prompt({ title: 'Motivo do cancelamento' });
     if (!reason) return;
     cancelRequest({ id, reason, userId: user.id, userName: user.name });
   };

--- a/src/pages/RequestsPage.jsx
+++ b/src/pages/RequestsPage.jsx
@@ -5,6 +5,7 @@ import { useBudgetRequests } from '../stores/budget-requests';
 import { Plus, Search, Edit, Eye, CheckCircle, XCircle, Clock, DollarSign, Upload } from 'lucide-react';
 import { useRequestsList, useRequestStats, useApproveRequest, useRejectRequest } from '../hooks/useRequests';
 import { useAuth } from '../contexts/AuthContext';
+import { usePrompt } from '../contexts/PromptContext';
 import { useNotifications } from '../stores/ui';
 import NewRequestModal from '../components/NewRequestModal';
 import ImportRequestsModal from '../components/ImportRequestsModal';
@@ -22,6 +23,7 @@ export const RequestsPage = () => {
   const [showImport, setShowImport] = useState(false);
   const approveRequest = useApproveRequest();
   const rejectRequest = useRejectRequest();
+  const prompt = usePrompt();
   const { error: notifyError } = useNotifications();
   const { requests: budgetRequests } = useBudgetRequests();
   const [showBudgetModal, setShowBudgetModal] = useState(false);
@@ -126,8 +128,8 @@ export const RequestsPage = () => {
     return labels[status] || '-';
   };
 
-  const handleApprove = (id) => {
-    const comments = window.prompt('Comentário da aprovação');
+  const handleApprove = async (id) => {
+    const comments = await prompt({ title: 'Comentário da aprovação' });
     if (comments === null) return;
     approveRequest.mutate({
       id,
@@ -137,8 +139,8 @@ export const RequestsPage = () => {
     });
   };
 
-  const handleReject = (id) => {
-    const reason = window.prompt('Motivo da reprovação');
+  const handleReject = async (id) => {
+    const reason = await prompt({ title: 'Motivo da reprovação' });
     if (!reason) return;
     rejectRequest.mutate({
       id,

--- a/src/pages/VendorApprovalsPage.jsx
+++ b/src/pages/VendorApprovalsPage.jsx
@@ -10,6 +10,7 @@ import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { formatCNPJ, formatDate } from '@/utils';
 import VendorDetailsModal from '@/components/VendorDetailsModal';
 import { useConfirm } from '@/hooks/useConfirm';
+import { usePrompt } from '@/contexts/PromptContext';
 
 export const VendorApprovalsPage = () => {
   const { data: vendorsData, isLoading, isError } = useVendors({
@@ -39,6 +40,7 @@ export const VendorApprovalsPage = () => {
   const requestInfoVendor = useRequestMoreInfoVendor();
 
   const { confirm, ConfirmationDialog } = useConfirm();
+  const prompt = usePrompt();
 
   const handleApprove = async (id) => {
     if (await confirm('Aprovar este fornecedor?')) {
@@ -47,14 +49,14 @@ export const VendorApprovalsPage = () => {
   };
 
   const handleReject = async (id) => {
-    const reason = window.prompt('Motivo da reprovação:');
+    const reason = await prompt({ title: 'Motivo da reprovação:' });
     if (reason) {
       await rejectVendor.mutateAsync({ id, reason });
     }
   };
 
   const handleRequestInfo = async (id) => {
-    const info = window.prompt('Quais informações adicionais são necessárias?');
+    const info = await prompt({ title: 'Quais informações adicionais são necessárias?' });
     if (info) {
       await requestInfoVendor.mutateAsync({ id, info });
     }


### PR DESCRIPTION
## Summary
- add reusable prompt provider backed by Radix AlertDialog
- replace window.prompt calls across pages with styled confirmation modals

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a771223cec832d8e952adc81e38442