### PR TITLE
feat: show budget results and export excel

### DIFF
--- a/src/services/requests.ts
+++ b/src/services/requests.ts
@@ -108,6 +108,7 @@ export const getTotalSpentByBudgetLine = async (
     collection(db, COLLECTION_NAME),
     where('budgetLineId', '==', budgetLineId),
     where('inBudget', '==', true),
+    where('status', 'in', ['pending_payment_approval', 'paid']),
     where('competenceDate', '>=', start),
     where('competenceDate', '<', end)
   );


### PR DESCRIPTION
## Summary
- show approved expenses and attainment in budgets page
- allow exporting budget lines to Excel
- filter approved requests when computing spent amounts

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7721feb10832d868b847151f2651a