### PR TITLE
feat: view request details from director approvals

### DIFF
--- a/src/pages/DirectorApprovalsPage.jsx
+++ b/src/pages/DirectorApprovalsPage.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useRequestsList, useApproveRequest, useRejectRequest } from '../hooks/useRequests';
 import { useAuth } from '../contexts/AuthContext';
 import { usePrompt } from '../contexts/PromptContext';
+import { useNavigate } from 'react-router-dom';
 
 export const DirectorApprovalsPage = () => {
   const { user } = useAuth();
@@ -9,6 +10,7 @@ export const DirectorApprovalsPage = () => {
   const approveRequest = useApproveRequest();
   const rejectRequest = useRejectRequest();
   const prompt = usePrompt();
+  const navigate = useNavigate();
   const requests = data?.data || [];
 
   const formatCurrency = (value) =>
@@ -24,6 +26,10 @@ export const DirectorApprovalsPage = () => {
     const reason = await prompt({ title: 'Motivo da reprovação' });
     if (!reason) return;
     rejectRequest.mutate({ id, approverId: user.id, approverName: user.name, reason });
+  };
+
+  const handleRowClick = (id) => {
+    navigate(`/director-approvals/${id}`);
   };
 
   return (
@@ -49,7 +55,11 @@ export const DirectorApprovalsPage = () => {
               </tr>
             ) : (
               requests.map((req) => (
-                <tr key={req.id}>
+                <tr
+                  key={req.id}
+                  onClick={() => handleRowClick(req.id)}
+                  className="cursor-pointer hover:bg-gray-50"
+                >
                   <td className="px-6 py-4 whitespace-nowrap">
                     <div className="text-sm font-medium text-gray-900">{req.requestNumber || req.number}</div>
                     <div className="text-sm text-gray-500 truncate max-w-xs">{req.description}</div>
@@ -62,13 +72,19 @@ export const DirectorApprovalsPage = () => {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
                     <button
-                      onClick={() => handleApprove(req.id)}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleApprove(req.id);
+                      }}
                       className="text-green-600 hover:text-green-900"
                     >
                       Aprovar
                     </button>
                     <button
-                      onClick={() => handleReject(req.id)}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleReject(req.id);
+                      }}
                       className="text-red-600 hover:text-red-900"
                     >
                       Reprovar

--- a/src/pages/RequestDetailsPage.jsx
+++ b/src/pages/RequestDetailsPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useLocation } from 'react-router-dom';
 import { useRequest } from '@/hooks/useRequests';
 
 const statusLabels = {
@@ -34,7 +34,10 @@ const formatDateTime = (date) =>
 
 export const RequestDetailsPage = () => {
   const { id } = useParams();
+  const location = useLocation();
   const { data: request, isLoading } = useRequest(id);
+
+  const backPath = location.pathname.split('/').slice(0, -1).join('/') || '/requests';
 
   if (isLoading) return <div>Carregando...</div>;
   if (!request) return <div>Solicitação não encontrada</div>;
@@ -43,7 +46,7 @@ export const RequestDetailsPage = () => {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Solicitação {request.requestNumber}</h1>
-        <Link to="/requests" className="text-blue-600 hover:underline text-sm">
+        <Link to={backPath} className="text-blue-600 hover:underline text-sm">
           Voltar
         </Link>
       </div>

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -102,6 +102,16 @@ export const AppRoutes = () => {
           }
         />
         <Route
+          path="director-approvals/:id"
+          element={
+            hasPageAccess('directorApprovals') ? (
+              <RequestDetailsPage />
+            ) : (
+              <Navigate to="/" replace />
+            )
+          }
+        />
+        <Route
           path="cfo-approvals"
           element={
             hasPageAccess('cfoApprovals') ? (


### PR DESCRIPTION
## Summary
- allow navigating to request details when clicking a row on director approvals
- support back navigation based on current route
- add route for director approval request details

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b02aebdc4c832dbbb1c714bdd2162d