### PR TITLE
feat: add budget line upload and add-line buttons

### DIFF
--- a/src/pages/BudgetsPage.jsx
+++ b/src/pages/BudgetsPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useActiveVendors } from '@/hooks/useVendors';
 import { useActiveCostCenters } from '@/hooks/useCostCenters';
@@ -35,10 +35,9 @@ const emptyMonths = {
 
 // Componente da página de Orçamento
 export const BudgetsPage = () => {
-  const { user } = useAuth();
-  // Permite que usuários com papel "finance" também editem o orçamento
-  const canEdit =
-    user.role === 'cost_center_owner' || user.role === 'finance';
+  const { user, hasAnyRole } = useAuth();
+  // Permite que usuários com papel "finance", "cost_center_owner" ou "admin" editem o orçamento
+  const canEdit = hasAnyRole(['cost_center_owner', 'finance', 'admin']);
   const { data: vendorsData } = useActiveVendors();
   const { data: costCentersData } = useActiveCostCenters();
   const vendors = vendorsData || [];
@@ -60,6 +59,7 @@ export const BudgetsPage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [showResults, setShowResults] = useState(false);
   const [results, setResults] = useState({});
+  const fileInputRef = useRef(null);
 
   useEffect(() => {
     const fetchItems = async () => {
@@ -118,6 +118,66 @@ export const BudgetsPage = () => {
   };
 
   const toggleResults = () => setShowResults((prev) => !prev);
+
+  const handleExcelUpload = async (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const data = await file.arrayBuffer();
+    const workbook = XLSX.read(data, { type: 'array' });
+    const sheet = workbook.Sheets[workbook.SheetNames[0]];
+    const rows = XLSX.utils.sheet_to_json(sheet, { header: 1 });
+    const [, ...lines] = rows;
+    const monthNames = [
+      'jan',
+      'fev',
+      'mar',
+      'abr',
+      'mai',
+      'jun',
+      'jul',
+      'ago',
+      'set',
+      'out',
+      'nov',
+      'dez',
+    ];
+    const getVendorIdByName = (name) =>
+      vendors.find((v) => v.name === name)?.id || '';
+    const getCostCenterIdByName = (name) =>
+      costCenters.find((c) => c.name === name)?.id || '';
+    const createdItems = [];
+    for (const line of lines) {
+      if (line.length === 0) continue;
+      const [
+        fornecedor,
+        descricao,
+        centroCusto,
+        natureza,
+        tipo,
+        ano,
+        ...months
+      ] = line;
+      const newItem = {
+        vendorId: getVendorIdByName(fornecedor),
+        description: descricao || '',
+        costCenterId: getCostCenterIdByName(centroCusto),
+        nature: natureza || 'fixo',
+        costType: tipo || 'OPEX',
+        year: Number(ano) || new Date().getFullYear(),
+        months: monthNames.reduce((acc, _, idx) => {
+          acc[idx + 1] = Number(months[idx]) || 0;
+          return acc;
+        }, {}),
+      };
+      const created = await createBudgetLine({
+        ...newItem,
+        createdBy: user.id,
+      });
+      createdItems.push(created);
+    }
+    setItems((prev) => [...prev, ...createdItems]);
+    e.target.value = '';
+  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -179,6 +239,13 @@ export const BudgetsPage = () => {
 
   return (
     <div className="space-y-6">
+      <input
+        type="file"
+        ref={fileInputRef}
+        accept=".xlsx"
+        className="hidden"
+        onChange={handleExcelUpload}
+      />
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Orçamento</h1>
@@ -198,15 +265,23 @@ export const BudgetsPage = () => {
             Baixar Excel
           </button>
           {canEdit && (
-            <button
-              onClick={() => {
-                resetForm();
-                setIsModalOpen(true);
-              }}
-              className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
-            >
-              Registrar novo orçamento
-            </button>
+            <>
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                className="px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700"
+              >
+                Upload Excel
+              </button>
+              <button
+                onClick={() => {
+                  resetForm();
+                  setIsModalOpen(true);
+                }}
+                className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+              >
+                Adicionar linha
+              </button>
+            </>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add button to create new budget line
- add mass budget upload from Excel
- display budget action buttons for admin, cost center owner, and finance roles

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b02eafc51c832d96f74564d6873921