### PR TITLE
feat: exibir solicitação de orçamento no sidebar

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -19,7 +19,7 @@ const navigation = [
   { name: 'Pagamentos', href: '/payments', icon: '💳', page: 'payments' },
   { name: 'Relatórios', href: '/reports', icon: '📊', page: 'reports' },
   { name: 'Orçamento', href: '/budgets', icon: '🗓️', page: 'budgets' },
-  { name: 'Solic. Orçamentos', href: '/budget-requests', icon: '📄', page: 'budgetRequests' },
+  { name: 'Solicitações de Orçamento', href: '/budget-requests', icon: '📄', page: 'budgetRequests' },
   { name: 'Parâmetros', href: '/settings', icon: '⚙️', page: 'settings' },
   { name: 'Usuários', href: '/users', icon: '👥', page: 'users' },
 ];

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -146,6 +146,7 @@ export const AuthProvider = ({ children }) => {
     payments: ['admin', 'finance'],
     reports: ['admin', 'finance'],
     budgets: ['admin', 'cost_center_owner'],
+    budgetRequests: ['admin', 'finance', 'cost_center_owner', 'user', 'director', 'cfo', 'ceo'],
     settings: ['cfo'],
   });
 


### PR DESCRIPTION
## Summary
- mostra o item "Solicitações de Orçamento" no menu lateral
- garante permissão de acesso para essa tela

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0332df9dc832d853ad66bbdb8f6b9