### PR TITLE
feat: avoid duplicate budget line uploads

### DIFF
--- a/src/pages/BudgetsPage.jsx
+++ b/src/pages/BudgetsPage.jsx
@@ -7,6 +7,7 @@ import {
   createBudgetLine,
   updateBudgetLine,
   deleteBudgetLine,
+  findBudgetLineByKey,
 } from '@/services/budgetLines';
 import { getTotalSpentByBudgetLine } from '@/services/requests';
 import * as XLSX from 'xlsx';
@@ -17,6 +18,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from '@/components/ui/dialog';
+import { useNotifications } from '@/stores/ui';
 
 const emptyMonths = {
   1: 0,
@@ -36,6 +38,7 @@ const emptyMonths = {
 // Componente da página de Orçamento
 export const BudgetsPage = () => {
   const { user, hasAnyRole } = useAuth();
+  const { warning } = useNotifications();
   // Permite que usuários com papel "finance", "cost_center_owner" ou "admin" editem o orçamento
   const canEdit = hasAnyRole(['cost_center_owner', 'finance', 'admin']);
   const { data: vendorsData } = useActiveVendors();
@@ -169,6 +172,16 @@ export const BudgetsPage = () => {
           return acc;
         }, {}),
       };
+      const existing = await findBudgetLineByKey(
+        newItem.vendorId,
+        newItem.description,
+        newItem.costCenterId,
+        newItem.year
+      );
+      if (existing) {
+        warning('Linha ignorada por duplicidade', `${descricao} - ${fornecedor} / ${centroCusto} (${ano})`);
+        continue;
+      }
       const created = await createBudgetLine({
         ...newItem,
         createdBy: user.id,

--- a/src/services/budgetLines.ts
+++ b/src/services/budgetLines.ts
@@ -58,6 +58,30 @@ export const findBudgetLine = async (
   } as BudgetLine;
 };
 
+export const findBudgetLineByKey = async (
+  vendorId: string,
+  description: string,
+  costCenterId: string,
+  year: number
+): Promise<BudgetLine | null> => {
+  const q = query(
+    collection(db, COLLECTION_NAME),
+    where('vendorId', '==', vendorId),
+    where('description', '==', description),
+    where('costCenterId', '==', costCenterId),
+    where('year', '==', year)
+  );
+  const snapshot = await getDocs(q);
+  if (snapshot.empty) return null;
+  const d = snapshot.docs[0];
+  return {
+    id: d.id,
+    ...d.data(),
+    createdAt: d.data().createdAt?.toDate ? d.data().createdAt.toDate() : undefined,
+    updatedAt: d.data().updatedAt?.toDate ? d.data().updatedAt.toDate() : undefined,
+  } as BudgetLine;
+};
+
 export const createBudgetLine = async (
   data: Omit<BudgetLine, 'id' | 'createdAt' | 'updatedAt'>
 ): Promise<BudgetLine> => {


### PR DESCRIPTION
## Summary
- add `findBudgetLineByKey` to query budget lines by unique fields
- skip creating duplicate budget lines on Excel import and warn user

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0659d4ffc832dba31fc6d7e9f9058