### PR TITLE
Reorder competence field in new request modal

### DIFF
--- a/src/components/NewRequestModal.jsx
+++ b/src/components/NewRequestModal.jsx
@@ -322,6 +322,10 @@ export const NewRequestModal = ({ open, onClose }) => {
             <Textarea value={justification} onChange={(e) => setJustification(e.target.value)} />
           </div>
           <div>
+            <label className="block text-sm font-medium mb-1" data-tooltip="Mês/ano de competência da despesa">Competência</label>
+            <Input type="month" value={competenceDate} onChange={(e) => setCompetenceDate(e.target.value)} required />
+          </div>
+          <div>
             <label className="block text-sm font-medium mb-1" data-tooltip="Centro de custo responsável">Centro de custo</label>
             <Select value={costCenterId} onValueChange={setCostCenterId}>
               <SelectTrigger className="w-full">
@@ -371,10 +375,6 @@ export const NewRequestModal = ({ open, onClose }) => {
           <div>
             <label className="block text-sm font-medium mb-1" data-tooltip="Data de emissão da nota fiscal">Data de emissão</label>
             <Input type="date" value={invoiceDate} onChange={(e) => setInvoiceDate(e.target.value)} required />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1" data-tooltip="Mês/ano de competência da despesa">Competência</label>
-            <Input type="month" value={competenceDate} onChange={(e) => setCompetenceDate(e.target.value)} required />
           </div>
           <div>
             <label className="block text-sm font-medium mb-1" data-tooltip="Data prevista para pagamento">Data de vencimento</label>


### PR DESCRIPTION
## Summary
- move "Competência" input before cost center in new request modal

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b09c968710832da7bcc143f065d405