### PR TITLE
Remover aprovações da página de solicitações e permitir exclusão inicial

### DIFF
--- a/src/hooks/useRequests.ts
+++ b/src/hooks/useRequests.ts
@@ -363,6 +363,24 @@ export const useCancelRequest = () => {
   });
 };
 
+// Hook para excluir solicitação
+export const useDeleteRequest = () => {
+  const queryClient = useQueryClient();
+  const { success, error } = useNotifications();
+
+  return useMutation({
+    mutationFn: (id: string) => requestsService.deleteRequest(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.requests });
+      success('Solicitação excluída com sucesso!');
+    },
+    onError: (err: any) => {
+      console.error('Erro ao excluir solicitação:', err);
+      error('Erro ao excluir solicitação', err.message || 'Tente novamente.');
+    },
+  });
+};
+
 // Hook para aprovar contrato da solicitação
 export const useApproveRequestContract = () => {
   const queryClient = useQueryClient();

--- a/src/services/requests.ts
+++ b/src/services/requests.ts
@@ -967,6 +967,24 @@ export const cancelRequest = async (
   }
 };
 
+// Excluir solicitação
+export const deleteRequest = async (id: string): Promise<void> => {
+  try {
+    const request = await getRequestById(id);
+    if (!request) throw new Error('Solicitação não encontrada');
+
+    const historyLength = request.statusHistory?.length || 0;
+    if (request.status !== 'pending_owner_approval' || historyLength > 1) {
+      throw new Error('Solicitação não pode ser excluída');
+    }
+
+    await deleteDoc(doc(db, COLLECTION_NAME, id));
+  } catch (error) {
+    console.error('Erro ao excluir solicitação:', error);
+    throw error;
+  }
+};
+
 // Aprovar contrato da solicitação
 export const approveRequestContract = async (id: string): Promise<void> => {
   try {


### PR DESCRIPTION
## Summary
- Oculta botões de aprovar/rejeitar nas solicitações do usuário
- Adiciona exclusão de solicitação pendente antes da primeira aprovação
- Adiciona hook e serviço para excluir solicitações

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68b09d702ba4832d94fa7422280b90c0