### PR TITLE
Show budget vs requested amounts in expense details

### DIFF
--- a/src/components/RequestDetailsModal.jsx
+++ b/src/components/RequestDetailsModal.jsx
@@ -40,6 +40,12 @@ const RequestDetailsModal = ({ requestId, open, onClose }) => {
 
   const closePreview = () => setPreview(null);
 
+  const refDate =
+    request?.competenceDate || request?.invoiceDate || request?.dueDate || null;
+  const month = refDate ? new Date(refDate).getMonth() + 1 : null;
+  const budgetedAmount =
+    budgetLine && month ? budgetLine.months?.[month] || 0 : null;
+
   return (
     <>
       <Dialog open={open} onOpenChange={onClose}>
@@ -68,7 +74,10 @@ const RequestDetailsModal = ({ requestId, open, onClose }) => {
                   <span className="font-medium">Categoria:</span> {category?.name || request.categoryId}
                 </div>
                 <div>
-                  <span className="font-medium">Valor:</span> {formatCurrency(request.amount)}
+                  <span className="font-medium">Valor Solicitado:</span> {formatCurrency(request.amount)}
+                </div>
+                <div>
+                  <span className="font-medium">Valor Orçado:</span> {budgetedAmount !== null ? formatCurrency(budgetedAmount) : '-'}
                 </div>
                 <div>
                   <span className="font-medium">Competência:</span> {request.competenceDate ? formatDate(request.competenceDate) : '-'}
@@ -92,9 +101,14 @@ const RequestDetailsModal = ({ requestId, open, onClose }) => {
                 <div>
                   <span className="font-medium">Em Orçamento:</span> {request.inBudget ? 'Sim' : 'Não'}
                 </div>
-                {request.inBudget && (
+                {request.budgetLineId && (
                   <div className="sm:col-span-2">
                     <span className="font-medium">Orçamento:</span> {budgetLine?.description || request.budgetLineId}
+                  </div>
+                )}
+                {request.isOverBudget && request.overBudgetReason && (
+                  <div className="sm:col-span-2">
+                    <span className="font-medium">Justificativa do Estouro:</span> {request.overBudgetReason}
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- always display budgeted amount next to requested amount
- show associated budget line even when over budget
- surface justification when a request exceeds its budget

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b09db7e808832d9d30c1414dcd25ba