### PR TITLE
feat: show budget line expenses and attainment

### DIFF
--- a/src/pages/BudgetsPage.jsx
+++ b/src/pages/BudgetsPage.jsx
@@ -9,7 +9,10 @@ import {
   deleteBudgetLine,
   findBudgetLineByKey,
 } from '@/services/budgetLines';
-import { getTotalSpentByBudgetLine } from '@/services/requests';
+import {
+  getTotalSpentByBudgetLine,
+  getRequestsByBudgetLine,
+} from '@/services/requests';
 import * as XLSX from 'xlsx';
 import {
   Dialog,
@@ -63,6 +66,7 @@ export const BudgetsPage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [showResults, setShowResults] = useState(false);
   const [results, setResults] = useState({});
+  const [expenses, setExpenses] = useState({});
   const fileInputRef = useRef(null);
 
   useEffect(() => {
@@ -77,6 +81,7 @@ export const BudgetsPage = () => {
     if (showResults) {
       const fetchResults = async () => {
         const res = {};
+        const exp = {};
         for (const item of items) {
           if (!item.id) continue;
           const monthsData = {};
@@ -88,8 +93,10 @@ export const BudgetsPage = () => {
             );
           }
           res[item.id] = monthsData;
+          exp[item.id] = await getRequestsByBudgetLine(item.id);
         }
         setResults(res);
+        setExpenses(exp);
       };
       fetchResults();
     }
@@ -262,6 +269,8 @@ export const BudgetsPage = () => {
     XLSX.utils.book_append_sheet(workbook, worksheet, 'Orçamento');
     XLSX.writeFile(workbook, 'orcamento.xlsx');
   };
+
+  const totalColumns = 6 + Object.keys(emptyMonths).length + (canEdit ? 1 : 0);
 
   return (
     <div className="space-y-6">
@@ -465,63 +474,120 @@ export const BudgetsPage = () => {
             </tr>
           </thead>
           <tbody>
-            {items.map((item, idx) => (
-              <tr key={item.id || idx} className="border-t">
-                <td className="px-2 py-2">{getVendorName(item.vendorId)}</td>
-                <td className="px-2 py-2">{item.description}</td>
-                <td className="px-2 py-2">{getCostCenterName(item.costCenterId)}</td>
-                <td className="px-2 py-2 capitalize">{item.nature}</td>
-                <td className="px-2 py-2">{item.costType}</td>
-                <td className="px-2 py-2">{item.year}</td>
-                {Object.keys(emptyMonths).map((m) => (
-                  <td key={m} className="px-2 py-2 text-right">
-                    <div className="flex flex-col items-end">
-                      <span>
-                        {item.months[m].toLocaleString('pt-BR', {
-                          style: 'currency',
-                          currency: 'BRL',
-                        })}
-                      </span>
-                      {showResults && results[item.id] && (
-                        <span className="text-xs text-gray-500">
-                          {results[item.id][m].toLocaleString('pt-BR', {
-                            style: 'currency',
-                            currency: 'BRL',
-                          })}{' '}
-                          (
-                          {item.months[m]
-                            ? Math.round(
-                                (results[item.id][m] / item.months[m]) * 100
-                              )
-                            : 0}
-                          %)
-                        </span>
-                      )}
-                    </div>
-                  </td>
-                ))}
-                {canEdit && (
-                  <td className="px-2 py-2 text-right space-x-2">
-                    <button
-                      onClick={() => handleEdit(idx)}
-                      className="text-blue-600 hover:underline"
-                    >
-                      Editar
-                    </button>
-                    <button
-                      onClick={() => handleDelete(idx)}
-                      className="text-red-600 hover:underline"
-                    >
-                      Excluir
-                    </button>
-                  </td>
-                )}
-              </tr>
-            ))}
+            {items.map((item, idx) => {
+              const totalBudget = Object.values(item.months).reduce(
+                (sum, v) => sum + v,
+                0
+              );
+              const totalSpent = Object.values(results[item.id] || {}).reduce(
+                (sum, v) => sum + v,
+                0
+              );
+              const attainment = totalBudget
+                ? Math.round(((totalBudget - totalSpent) / totalBudget) * 100)
+                : 100;
+              return (
+                <React.Fragment key={item.id || idx}>
+                  <tr className="border-t">
+                    <td className="px-2 py-2">{getVendorName(item.vendorId)}</td>
+                    <td className="px-2 py-2">{item.description}</td>
+                    <td className="px-2 py-2">{getCostCenterName(item.costCenterId)}</td>
+                    <td className="px-2 py-2 capitalize">{item.nature}</td>
+                    <td className="px-2 py-2">{item.costType}</td>
+                    <td className="px-2 py-2">{item.year}</td>
+                    {Object.keys(emptyMonths).map((m) => (
+                      <td key={m} className="px-2 py-2 text-right">
+                        <div className="flex flex-col items-end">
+                          <span>
+                            {item.months[m].toLocaleString('pt-BR', {
+                              style: 'currency',
+                              currency: 'BRL',
+                            })}
+                          </span>
+                          {showResults && results[item.id] && (
+                            <span className="text-xs text-gray-500">
+                              {results[item.id][m].toLocaleString('pt-BR', {
+                                style: 'currency',
+                                currency: 'BRL',
+                              })}{' '}
+                              (
+                              {item.months[m]
+                                ? Math.round(
+                                    (results[item.id][m] / item.months[m]) * 100
+                                  )
+                                : 0}
+                              %)
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                    ))}
+                    {canEdit && (
+                      <td className="px-2 py-2 text-right space-x-2">
+                        <button
+                          onClick={() => handleEdit(idx)}
+                          className="text-blue-600 hover:underline"
+                        >
+                          Editar
+                        </button>
+                        <button
+                          onClick={() => handleDelete(idx)}
+                          className="text-red-600 hover:underline"
+                        >
+                          Excluir
+                        </button>
+                      </td>
+                    )}
+                  </tr>
+                  {showResults && expenses[item.id] && expenses[item.id].length > 0 && (
+                    <tr className="bg-gray-50">
+                      <td colSpan={totalColumns} className="px-2 py-2">
+                        <div className="space-y-1">
+                          {expenses[item.id].map((exp) => {
+                            const date = exp.competenceDate
+                              ? new Date(exp.competenceDate)
+                              : null;
+                            return (
+                              <div
+                                key={exp.id}
+                                className="flex justify-between text-sm"
+                              >
+                                <span>
+                                  {exp.description}
+                                  {date
+                                    ? ` (${date.toLocaleDateString('pt-BR')})`
+                                    : ''}
+                                </span>
+                                <span>
+                                  {exp.amount.toLocaleString('pt-BR', {
+                                    style: 'currency',
+                                    currency: 'BRL',
+                                  })}
+                                </span>
+                              </div>
+                            );
+                          })}
+                          <div className="flex justify-between text-sm font-semibold border-t pt-1 mt-1">
+                            <span>Total gasto</span>
+                            <span>
+                              {totalSpent.toLocaleString('pt-BR', {
+                                style: 'currency',
+                                currency: 'BRL',
+                              })}{' '}
+                              (Atingimento: {attainment}%)
+                            </span>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
+              );
+            })}
             {items.length === 0 && (
               <tr>
                 <td
-                  colSpan={canEdit ? 18 : 17}
+                  colSpan={totalColumns}
                   className="px-2 py-4 text-center text-gray-500"
                 >
                   Nenhuma linha adicionada

--- a/src/services/requests.ts
+++ b/src/services/requests.ts
@@ -118,6 +118,33 @@ export const getTotalSpentByBudgetLine = async (
   return snapshot.docs.reduce((sum, d) => sum + (d.data().amount || 0), 0);
 };
 
+export const getRequestsByBudgetLine = async (
+  budgetLineId: string
+): Promise<PaymentRequest[]> => {
+  const q = query(
+    collection(db, COLLECTION_NAME),
+    where('budgetLineId', '==', budgetLineId),
+    where('inBudget', '==', true),
+    where('status', 'in', ['pending_payment_approval', 'pending_payment', 'paid'])
+  );
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map((doc) => {
+    const data = doc.data();
+    return {
+      id: doc.id,
+      ...data,
+      createdAt: data.createdAt?.toDate() || new Date(),
+      updatedAt: data.updatedAt?.toDate() || new Date(),
+      dueDate: data.dueDate?.toDate() || null,
+      invoiceDate: data.invoiceDate?.toDate() || null,
+      competenceDate: data.competenceDate?.toDate() || null,
+      approvedAt: data.approvedAt?.toDate() || null,
+      rejectedAt: data.rejectedAt?.toDate() || null,
+      paidAt: data.paidAt?.toDate() || null,
+    } as PaymentRequest;
+  });
+};
+
 // Listar solicitações com paginação
 export const getRequests = async (
   params: PaginationParams & {


### PR DESCRIPTION
## Summary
- display expenses tied to each budget line with attainment percentage
- add service to fetch requests by budget line

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a1f05814832d86cc2bd513718f08