### PR TITLE
feat: show budget difference in request modal

### DIFF
--- a/src/components/RequestDetailsModal.jsx
+++ b/src/components/RequestDetailsModal.jsx
@@ -45,6 +45,8 @@ const RequestDetailsModal = ({ requestId, open, onClose }) => {
   const month = refDate ? new Date(refDate).getMonth() + 1 : null;
   const budgetedAmount =
     budgetLine && month ? budgetLine.months?.[month] || 0 : null;
+  const difference =
+    budgetedAmount !== null ? request.amount - budgetedAmount : null;
 
   return (
     <>
@@ -79,11 +81,16 @@ const RequestDetailsModal = ({ requestId, open, onClose }) => {
                 <div>
                   <span className="font-medium">Valor Orçado:</span> {budgetedAmount !== null ? formatCurrency(budgetedAmount) : '-'}
                 </div>
-                {request.inBudget && (
-                  <div>
-                    <span className="font-medium">Valor Orçado:</span> {budgetedAmount !== null ? formatCurrency(budgetedAmount) : '-'}
-                  </div>
-                )}
+                <div>
+                  <span className="font-medium">Diferença:</span>{' '}
+                  {difference !== null ? (
+                    <span className={difference > 0 ? 'text-red-600 font-bold' : ''}>
+                      {formatCurrency(difference)}
+                    </span>
+                  ) : (
+                    '-'
+                  )}
+                </div>
                 <div>
                   <span className="font-medium">Competência:</span> {request.competenceDate ? formatDate(request.competenceDate) : '-'}
                 </div>


### PR DESCRIPTION
## Summary
- display difference between requested and budgeted amounts in expense details
- highlight overspent requests in details modal

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a37d2f34832d97d0b8d8b0e2b531